### PR TITLE
ci: run iOS build on macos-26 for Expo SDK 55

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,11 @@ jobs:
 
   ios:
     name: iOS
-    runs-on: macos-15
+    # Expo SDK 55's expo-modules-core uses Swift 6 strict concurrency, which only
+    # compiles with Xcode 26+. The macos-15 runner tops out at Xcode 16.4 and
+    # fails with `unknown attribute 'MainActor'` and MainActor-isolation errors
+    # in expo-modules-core. macos-26 ships Xcode 26.2 by default, which builds.
+    runs-on: macos-26
     needs: lint
     steps:
       - uses: actions/checkout@v6
@@ -105,5 +109,6 @@ jobs:
           cd ios
           xcodebuild -workspace gotakmobile.xcworkspace -scheme gotakmobile \
             -configuration Debug -sdk iphonesimulator \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
-            -derivedDataPath build ONLY_ACTIVE_ARCH=NO
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath build ONLY_ACTIVE_ARCH=NO \
+            CODE_SIGNING_ALLOWED=NO build


### PR DESCRIPTION
## Summary

Expo SDK 55's `expo-modules-core` adopted Swift 6 strict concurrency, which only compiles cleanly with Xcode 26 or newer (see [expo/expo#42525](https://github.com/expo/expo/issues/42525) and [expo/expo#40369](https://github.com/expo/expo/pull/40369)).

The CI iOS job runs on `macos-15`, whose latest Xcode is 16.4, and has been failing on every push since the SDK 55 upgrade with errors like:

- `unknown attribute 'MainActor'`
- `main actor-isolated initializer 'init()' in a synchronous nonisolated context`
- `main actor-isolated property 'props' can not be referenced from a nonisolated context`
- `stored property 'completionHandler' of 'Sendable'-conforming class ... has non-sendable type`

All of these come from `node_modules/expo-modules-core/ios/**` (e.g. `SwiftUIHostingView.swift`, `SwiftUIVirtualView.swift`, `ExpoReactDelegate.swift`, `PersistentFileLog.swift`). They are a compiler/SDK mismatch, not a code bug in this repo, so the fix is at the CI level.

Changes:

- Switch iOS job runner from `macos-15` → `macos-26`. That runner ships Xcode 26.2 by default, which supports the Swift 6 concurrency model SDK 55 requires.
- Swap the simulator destination from `platform=iOS Simulator,name=iPhone 16` → `generic/platform=iOS Simulator` so the build isn't tied to a specific device name/runtime that may or may not exist on the new image.
- Add `CODE_SIGNING_ALLOWED=NO build` to mirror the pattern already used in `icco/etu-mobile`'s iOS CI.

## Test plan

- [x] CI `Lint` job passes (unchanged).
- [x] CI `Android` job passes (unchanged).
- [x] CI `iOS` job passes — this PR's focus. Previously failed on `main` with Swift concurrency errors in `expo-modules-core`; now compiles on Xcode 26.2 (13m47s).