### PR TITLE
feat: finish playable mobile client with auth and AI

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,25 +2,56 @@ import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 import { StatusBar } from 'expo-status-bar';
+import { ActivityIndicator, View, StyleSheet } from 'react-native';
 import { RootStackParamList } from './src/types/navigation';
+import { AuthProvider, useAuth } from './src/context/AuthContext';
 import { HomeScreen } from './src/screens/HomeScreen';
 import { GameScreen } from './src/screens/GameScreen';
+import { LoginScreen } from './src/screens/LoginScreen';
 
 const Stack = createStackNavigator<RootStackParamList>();
 
-export default function App() {
+function RootNavigator() {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <View style={styles.loading}>
+        <ActivityIndicator size="large" color="#3498db" />
+      </View>
+    );
+  }
+
   return (
-    <NavigationContainer>
-      <StatusBar style="light" />
-      <Stack.Navigator
-        initialRouteName="Home"
-        screenOptions={{
-          headerShown: false,
-        }}
-      >
-        <Stack.Screen name="Home" component={HomeScreen} />
-        <Stack.Screen name="Game" component={GameScreen} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <Stack.Navigator screenOptions={{ headerShown: false }}>
+      {isAuthenticated ? (
+        <>
+          <Stack.Screen name="Home" component={HomeScreen} />
+          <Stack.Screen name="Game" component={GameScreen} />
+        </>
+      ) : (
+        <Stack.Screen name="Login" component={LoginScreen} />
+      )}
+    </Stack.Navigator>
   );
 }
+
+export default function App() {
+  return (
+    <AuthProvider>
+      <NavigationContainer>
+        <StatusBar style="light" />
+        <RootNavigator />
+      </NavigationContainer>
+    </AuthProvider>
+  );
+}
+
+const styles = StyleSheet.create({
+  loading: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#2c3e50',
+  },
+});

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,40 +1,32 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for working in gotak-mobile.
 
-## Project Overview
+## Overview
 
-This is a React Native application for playing Tak, a board game similar to checkers or Go. The mobile app connects to a backend service at https://gotak.app with API documentation at https://gotak.app/swagger/doc.json.
+Expo React Native client for Tak. Talks to https://gotak.app (override with `EXPO_PUBLIC_API_URL`).
 
-### Key Requirements
-- **Isometric board rendering**: The board must be rendered in 3D isometric view to show piece stacks, not 2D
-- **Drag and drop functionality**: Players need to drag pieces from their inventory and move pieces on the board
-- **No offline mode or authentication** in initial version
-- **Cross-platform**: Must generate both iOS and Android apps using React Native
+## Requirements
 
-### Game Features to Implement
-- Render the board in an isometric grid showing piece stacks
-- Allow dragging and dropping of pieces
-- Display player's unplayed pieces
-- Start new games and share game links
-- Follow official Tak rules (https://ustak.org/play-beautiful-game-tak/)
+- Auth via `/auth/login` and `/auth/register`; JWT in SecureStore
+- Isometric board showing stacks
+- Place pieces and stack slides via PTN
+- Human vs human (poll) and human vs AI (`/ai-move`)
+- Trust server board state — do not reconstruct moves client-side
 
-## Backend Integration
+## Commands
 
-The backend service is at https://github.com/icco/gotak with Swagger documentation at https://gotak.app/swagger/doc.json. All game state and logic should be managed server-side.
+```bash
+yarn install
+yarn start
+yarn typecheck
+yarn lint
+yarn test
+```
 
-## Development Setup
+## Architecture
 
-This repository is in early stages and doesn't yet contain React Native configuration. When setting up:
-
-1. Initialize React Native project structure
-2. Set up API client for gotak.app backend
-3. Implement isometric board renderer (critical requirement)
-4. Add drag/drop gesture handling
-5. Create game state management connected to backend
-
-## Architecture Notes
-
-- Focus on real-time multiplayer functionality through backend API
-- Prioritize 3D visual representation over 2D approaches
-- Design for mobile-first touch interactions
+- `src/services/api.ts` — axios client with Bearer interceptor
+- `src/context/AuthContext.tsx` — session restore / login / logout
+- `src/utils/ptn.ts` — PTN builders for place and slide
+- Game create uses `Accept: application/json` so the server returns 201 + enriched `GameStateResponse`

--- a/README.md
+++ b/README.md
@@ -1,62 +1,55 @@
 # Gotak Mobile
 
-This is a React Native application built with Expo that creates iOS and Android apps for playing Tak, the beautiful board game.
-
-## About Tak
-
-Tak is a two-player board game where you build roads of stones to connect opposite sides of the board. The game uses two colors of pieces similar to checkers or Go. Learn more about the rules at [US Tak Association](https://ustak.org/play-beautiful-game-tak/).
-
-## Backend Integration
-
-The backend service is at https://github.com/icco/gotak, with API documentation at https://gotak.app/swagger/doc.json.
+Expo / React Native client for [Tak](https://ustak.org/play-beautiful-game-tak/), backed by [gotak](https://github.com/icco/gotak) at https://gotak.app.
 
 ## Features
 
-✅ **Implemented:**
-- Isometric 3D board rendering (shows piece stacks)
-- Interactive piece selection and placement
-- Game creation and sharing functionality
-- Real-time API integration with gotak.app
-- Cross-platform mobile support (iOS & Android)
+**Implemented**
+- Email/password login and registration (JWT stored in SecureStore)
+- New game vs human or vs AI
+- Join game by slug
+- Isometric board with stacks
+- Place flat / standing / capstone (PTN)
+- Stack slides to adjacent squares
+- Human games poll for opponent moves
+- AI games call `/ai-move` after your turn
+- Share game link
 
-🚧 **In Development:**
-- Drag and drop gestures
-- Move validation
-- Multiplayer synchronization
-
-🔮 **Future Plans:**
-- User authentication
+**Deferred**
+- Google OAuth
 - Offline mode
-- Game history
-- AI opponent
+- Spectating / WebSockets
+- Drag-and-drop gestures
+- App Store / Play Store release builds
 
-## Development
+## Setup
 
-### Prerequisites
-- Node.js 18+
-- Expo CLI
-- iOS Simulator (for iOS development)
-- Android Studio/Emulator (for Android development)
-
-### Setup
 ```bash
-npm install
-npm start
+yarn install
+yarn start
 ```
 
-### Building
-```bash
-# Development builds
-expo build:android --type apk
-expo build:ios
+Optional API override:
 
-# Production
-expo build:android --type app-bundle
+```bash
+EXPO_PUBLIC_API_URL=http://localhost:8080 yarn start
 ```
 
-### Project Structure
-- `src/components/` - Reusable UI components
-- `src/screens/` - Screen components
-- `src/services/` - API and external services  
-- `src/types/` - TypeScript type definitions
-- `src/utils/` - Utility functions
+Defaults to `https://gotak.app`.
+
+## Scripts
+
+| Command | Description |
+|---------|-------------|
+| `yarn start` | Expo dev server |
+| `yarn lint` | ESLint |
+| `yarn typecheck` | TypeScript |
+| `yarn test` | Unit tests (PTN / inventory) |
+
+## Project structure
+
+- `src/components/` — board and inventory UI
+- `src/screens/` — login, home, game
+- `src/services/` — API client and SecureStore auth
+- `src/context/` — auth session
+- `src/utils/` — PTN helpers

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import 'react-native-gesture-handler';
 import { registerRootComponent } from 'expo';
 
 import App from './App';

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.test.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "web": "expo start --web",
     "lint": "eslint src --ext .ts,.tsx",
     "typecheck": "tsc --noEmit",
-    "test": "echo \"No tests configured yet\""
+    "test": "jest"
   },
   "dependencies": {
     "@react-navigation/native": "^7.3.8",
@@ -18,20 +18,27 @@
     "expo": "^55.0.8",
     "expo-linking": "~55.0.8",
     "expo-screen-orientation": "~55.0.9",
+    "expo-secure-store": "^57.0.1",
     "expo-status-bar": "~55.0.4",
     "react": "19.2.4",
     "react-native": "0.83.2",
     "react-native-gesture-handler": "~2.30.0",
     "react-native-reanimated": "4.2.2",
+    "react-native-safe-area-context": "^5.8.0",
+    "react-native-screens": "^4.26.2",
     "react-native-share": "^12.2.0",
     "react-native-svg": "15.15.4",
     "react-native-worklets": "0.7.4"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",
+    "@types/jest": "^30.0.0",
     "@types/react": "~19.2.14",
+    "@types/react-test-renderer": "^19.1.0",
     "eslint": "^9.39.4",
     "eslint-config-expo": "~55.0.1",
+    "jest": "^30.4.2",
+    "ts-jest": "^29.4.11",
     "typescript": "~5.9.3"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "react-native": "0.83.2",
     "react-native-gesture-handler": "~2.30.0",
     "react-native-reanimated": "4.2.2",
-    "react-native-safe-area-context": "^5.8.0",
-    "react-native-screens": "^4.26.2",
+    "react-native-safe-area-context": "~5.6.2",
+    "react-native-screens": "~4.23.0",
     "react-native-share": "^12.2.0",
     "react-native-svg": "15.15.4",
     "react-native-worklets": "0.7.4"

--- a/src/components/IsometricBoard.tsx
+++ b/src/components/IsometricBoard.tsx
@@ -1,55 +1,53 @@
 import React from 'react';
 import { View, StyleSheet, TouchableOpacity, Dimensions } from 'react-native';
 import Svg, { Line } from 'react-native-svg';
-import { Board, Stone, PieceType } from '../types/game';
+import { PieceType, UIBoard, UIStone } from '../types/game';
 
 interface Props {
-  board: Board;
+  board: UIBoard;
   onSquarePress: (x: number, y: number) => void;
   selectedPieceType?: PieceType;
+  selectedSquare?: string;
 }
 
-export const IsometricBoard: React.FC<Props> = ({ board, onSquarePress, selectedPieceType }) => {
+export const IsometricBoard: React.FC<Props> = ({
+  board,
+  onSquarePress,
+  selectedPieceType,
+  selectedSquare,
+}) => {
   const screenWidth = Dimensions.get('window').width;
-  const boardSize = Math.min(screenWidth - 32, 400);
+  const boardPixelSize = Math.min(screenWidth - 32, 400);
 
-  // Isometric projection constants
-  const tileWidth = boardSize / (board.size + 1);
-  const tileHeight = tileWidth * 0.6; // Isometric height ratio
-  const pieceHeight = tileHeight * 0.25; // Height of each piece in the stack
+  const tileWidth = boardPixelSize / (board.size + 1);
+  const tileHeight = tileWidth * 0.6;
+  const pieceHeight = tileHeight * 0.25;
 
-  // Convert board.squares object to array of squares with coordinates
   const getSquaresArray = () => {
-    const squares: { x: number; y: number; stones: Stone[] }[] = [];
-
+    const squares: { x: number; y: number; key: string; stones: UIStone[] }[] = [];
     for (let y = 0; y < board.size; y++) {
       for (let x = 0; x < board.size; x++) {
-        const file = String.fromCharCode(97 + x); // 'a' starts at 97
+        const file = String.fromCharCode(97 + x);
         const rank = y + 1;
         const key = `${file}${rank}`;
-        const stones = board.squares[key] || [];
-        squares.push({ x, y, stones });
+        squares.push({ x, y, key, stones: board.squares[key] || [] });
       }
     }
-
     return squares;
   };
 
-  // Convert grid coordinates to isometric coordinates
   const gridToIsometric = (x: number, y: number) => {
-    // Center the board
-    const centerX = boardSize / 2;
-    const centerY = boardSize * 0.4;
-
-    // Isometric projection
+    const centerX = boardPixelSize / 2;
+    const centerY = boardPixelSize * 0.4;
     const isoX = centerX + (x - y) * tileWidth * 0.5;
     const isoY = centerY + (x + y) * tileHeight * 0.5;
     return { x: isoX, y: isoY };
   };
 
-  const renderSquare = (x: number, y: number, stones: Stone[]) => {
+  const renderSquare = (x: number, y: number, key: string, stones: UIStone[]) => {
     const isoPos = gridToIsometric(x, y);
-    const canPlacePiece = selectedPieceType && stones.length === 0;
+    const canPlacePiece = Boolean(selectedPieceType && stones.length === 0);
+    const isSelected = selectedSquare === key;
 
     return (
       <View
@@ -62,15 +60,14 @@ export const IsometricBoard: React.FC<Props> = ({ board, onSquarePress, selected
             top: isoPos.y - tileHeight / 2,
             width: tileWidth,
             height: tileHeight,
-            backgroundColor: canPlacePiece ? 'rgba(255, 215, 0, 0.4)' : 'rgba(210, 180, 140, 0.4)',
-            borderWidth: canPlacePiece ? 2 : 1,
-            borderColor: canPlacePiece ? '#ffd700' : '#8b4513',
-            shadowColor: '#000',
-            shadowOffset: { width: 2, height: 2 },
-            shadowOpacity: 0.3,
-            shadowRadius: 3,
-            elevation: 3,
-          }
+            backgroundColor: isSelected
+              ? 'rgba(52, 152, 219, 0.5)'
+              : canPlacePiece
+                ? 'rgba(255, 215, 0, 0.4)'
+                : 'rgba(210, 180, 140, 0.4)',
+            borderWidth: canPlacePiece || isSelected ? 2 : 1,
+            borderColor: isSelected ? '#3498db' : canPlacePiece ? '#ffd700' : '#8b4513',
+          },
         ]}
       >
         <TouchableOpacity
@@ -81,29 +78,25 @@ export const IsometricBoard: React.FC<Props> = ({ board, onSquarePress, selected
     );
   };
 
-  const renderStone = (stone: Stone, x: number, y: number, stackIndex: number) => {
+  const renderStone = (stone: UIStone, x: number, y: number, stackIndex: number) => {
     const isoPos = gridToIsometric(x, y);
     const stackHeight = stackIndex * pieceHeight;
     const pieceSize = tileWidth * 0.35;
-    const color = stone.player === 1 ? '#f8f9fa' : '#2c3e50'; // 1 = white, 2 = black
+    const color = stone.player === 1 ? '#f8f9fa' : '#2c3e50';
     const strokeColor = stone.player === 1 ? '#dee2e6' : '#1a252f';
+    const stoneType = stone.type.toUpperCase();
 
-    // Handle different possible type values from the API
-    const stoneType = stone.type?.toLowerCase() || 'flat';
-
-    if (stoneType === 'wall' || stoneType === 'standing') {
-      // Standing piece - render as a tall rectangle
+    if (stoneType === 'S') {
       const height = pieceHeight * 1.5;
       const width = pieceSize * 0.7;
-
       return (
         <View
-          key={`stone-${stackIndex}`}
+          key={`stone-${x}-${y}-${stackIndex}`}
           style={[
             styles.stone,
             {
-              width: width,
-              height: height,
+              width,
+              height,
               backgroundColor: color,
               borderWidth: 1,
               borderColor: strokeColor,
@@ -111,95 +104,52 @@ export const IsometricBoard: React.FC<Props> = ({ board, onSquarePress, selected
               left: isoPos.x - width / 2,
               top: isoPos.y - tileHeight / 2 - stackHeight - height,
               zIndex: 100 + stackIndex,
-              shadowColor: '#000',
-              shadowOffset: { width: 1, height: 2 },
-              shadowOpacity: 0.4,
-              shadowRadius: 2,
-              elevation: 5,
-            }
-          ]}
-        />
-      );
-    } else if (stoneType === 'capstone') {
-      // Capstone - render as a larger circle with special styling
-      const radius = pieceSize * 0.6;
-
-      return (
-        <View
-          key={`stone-${stackIndex}`}
-          style={[
-            styles.stone,
-            {
-              width: radius * 2,
-              height: radius * 2,
-              borderRadius: radius,
-              backgroundColor: color,
-              borderWidth: 3,
-              borderColor: strokeColor,
-              position: 'absolute',
-              left: isoPos.x - radius,
-              top: isoPos.y - tileHeight / 2 - stackHeight - radius * 2,
-              zIndex: 100 + stackIndex,
-              shadowColor: '#000',
-              shadowOffset: { width: 1, height: 2 },
-              shadowOpacity: 0.4,
-              shadowRadius: 3,
-              elevation: 6,
-            }
-          ]}
-        />
-      );
-    } else {
-      // Flat stone - render as a regular circle
-      const radius = pieceSize * 0.4;
-
-      return (
-        <View
-          key={`stone-${stackIndex}`}
-          style={[
-            styles.stone,
-            {
-              width: radius * 2,
-              height: radius * 2,
-              borderRadius: radius,
-              backgroundColor: color,
-              borderWidth: 1,
-              borderColor: strokeColor,
-              position: 'absolute',
-              left: isoPos.x - radius,
-              top: isoPos.y - tileHeight / 2 - stackHeight - radius * 2,
-              zIndex: 100 + stackIndex,
-              shadowColor: '#000',
-              shadowOffset: { width: 1, height: 1 },
-              shadowOpacity: 0.3,
-              shadowRadius: 2,
-              elevation: 4,
-            }
+            },
           ]}
         />
       );
     }
+
+    const radius = stoneType === 'C' ? pieceSize * 0.55 : pieceSize * 0.45;
+    return (
+      <View
+        key={`stone-${x}-${y}-${stackIndex}`}
+        style={[
+          styles.stone,
+          {
+            width: radius * 2,
+            height: radius * 2,
+            borderRadius: radius,
+            backgroundColor: color,
+            borderWidth: stoneType === 'C' ? 2 : 1,
+            borderColor: strokeColor,
+            position: 'absolute',
+            left: isoPos.x - radius,
+            top: isoPos.y - tileHeight / 2 - stackHeight - radius * 2,
+            zIndex: 100 + stackIndex,
+          },
+        ]}
+      />
+    );
   };
 
   const renderGridLines = () => {
     const lines = [];
     const stroke = 'rgba(139, 69, 19, 0.6)';
 
-    // Lines along the y-axis (constant x)
     for (let x = 0; x <= board.size; x++) {
       const a = gridToIsometric(x - 0.5, -0.5);
       const b = gridToIsometric(x - 0.5, board.size - 0.5);
       lines.push(
-        <Line key={`vline-${x}`} x1={a.x} y1={a.y} x2={b.x} y2={b.y} stroke={stroke} strokeWidth={1} />
+        <Line key={`vline-${x}`} x1={a.x} y1={a.y} x2={b.x} y2={b.y} stroke={stroke} strokeWidth={1} />,
       );
     }
 
-    // Lines along the x-axis (constant y)
     for (let y = 0; y <= board.size; y++) {
       const a = gridToIsometric(-0.5, y - 0.5);
       const b = gridToIsometric(board.size - 0.5, y - 0.5);
       lines.push(
-        <Line key={`hline-${y}`} x1={a.x} y1={a.y} x2={b.x} y2={b.y} stroke={stroke} strokeWidth={1} />
+        <Line key={`hline-${y}`} x1={a.x} y1={a.y} x2={b.x} y2={b.y} stroke={stroke} strokeWidth={1} />,
       );
     }
 
@@ -209,45 +159,19 @@ export const IsometricBoard: React.FC<Props> = ({ board, onSquarePress, selected
   const squares = getSquaresArray();
 
   return (
-    <View style={[styles.container, { width: boardSize, height: boardSize * 0.8 }]}>
-      {/* Background board */}
-      <View style={[styles.boardBackground, { width: boardSize, height: boardSize * 0.8 }]}>
-        {/* Board border */}
-        <View
-          style={{
-            position: 'absolute',
-            left: 0,
-            top: 0,
-            width: boardSize,
-            height: boardSize * 0.8,
-            borderWidth: 3,
-            borderColor: '#8b4513',
-            backgroundColor: 'rgba(139, 69, 19, 0.1)',
-            shadowColor: '#000',
-            shadowOffset: { width: 0, height: 4 },
-            shadowOpacity: 0.3,
-            shadowRadius: 6,
-            elevation: 8,
-          }}
-        />
-      </View>
-
-      {/* Grid lines */}
+    <View style={[styles.container, { width: boardPixelSize, height: boardPixelSize * 0.8 }]}>
       <Svg
-        width={boardSize}
-        height={boardSize * 0.8}
+        width={boardPixelSize}
+        height={boardPixelSize * 0.8}
         style={StyleSheet.absoluteFill}
         pointerEvents="none"
       >
         {renderGridLines()}
       </Svg>
 
-      {/* Squares */}
-      {squares.map(({ x, y, stones }) => renderSquare(x, y, stones))}
-
-      {/* Stones - render on top of squares */}
+      {squares.map(({ x, y, key, stones }) => renderSquare(x, y, key, stones))}
       {squares.map(({ x, y, stones }) =>
-        stones.map((stone, stackIndex) => renderStone(stone, x, y, stackIndex))
+        stones.map((stone, stackIndex) => renderStone(stone, x, y, stackIndex)),
       )}
     </View>
   );
@@ -262,15 +186,6 @@ const styles = StyleSheet.create({
     marginVertical: 16,
     borderWidth: 2,
     borderColor: '#34495e',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.3,
-    shadowRadius: 8,
-    elevation: 10,
-  },
-  boardBackground: {
-    position: 'absolute',
-    backgroundColor: '#34495e',
   },
   isometricSquare: {
     justifyContent: 'center',
@@ -279,8 +194,6 @@ const styles = StyleSheet.create({
   squareTouchable: {
     width: '100%',
     height: '100%',
-    justifyContent: 'center',
-    alignItems: 'center',
   },
   stone: {
     justifyContent: 'center',

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,129 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { AuthUser } from '../types/game';
+import { gotakAPI } from '../services/api';
+import {
+  clearStoredAuth,
+  getStoredAuth,
+  setStoredAuth,
+} from '../services/authStorage';
+import { logException } from '../utils/logger';
+
+interface AuthState {
+  user: AuthUser | null;
+  token: string | null;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+}
+
+interface AuthContextValue extends AuthState {
+  login: (email: string, password: string) => Promise<void>;
+  register: (email: string, password: string, name: string) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState<AuthState>({
+    user: null,
+    token: null,
+    isLoading: true,
+    isAuthenticated: false,
+  });
+
+  const applySession = useCallback((token: string | null, user: AuthUser | null) => {
+    gotakAPI.setToken(token);
+    setState({
+      user,
+      token,
+      isLoading: false,
+      isAuthenticated: Boolean(token && user),
+    });
+  }, []);
+
+  const logout = useCallback(async () => {
+    await clearStoredAuth();
+    applySession(null, null);
+  }, [applySession]);
+
+  useEffect(() => {
+    gotakAPI.setUnauthorizedHandler(() => {
+      void logout();
+    });
+    return () => gotakAPI.setUnauthorizedHandler(null);
+  }, [logout]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const stored = await getStoredAuth();
+      if (cancelled) return;
+      if (!stored) {
+        applySession(null, null);
+        return;
+      }
+      gotakAPI.setToken(stored.token);
+      try {
+        const profile = await gotakAPI.getProfile();
+        if (cancelled) return;
+        await setStoredAuth(stored.token, profile);
+        applySession(stored.token, profile);
+      } catch (error) {
+        logException(error instanceof Error ? error : new Error(String(error)), {
+          method: 'restoreSession',
+        });
+        await clearStoredAuth();
+        if (!cancelled) {
+          applySession(null, null);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [applySession]);
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      const { token, user } = await gotakAPI.login(email.trim(), password);
+      await setStoredAuth(token, user);
+      applySession(token, user);
+    },
+    [applySession],
+  );
+
+  const register = useCallback(
+    async (email: string, password: string, name: string) => {
+      await gotakAPI.register(email.trim(), password, name.trim());
+      await login(email, password);
+    },
+    [login],
+  );
+
+  const value = useMemo(
+    () => ({
+      ...state,
+      login,
+      register,
+      logout,
+    }),
+    [state, login, register, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth must be used within AuthProvider');
+  }
+  return ctx;
+}

--- a/src/screens/GameScreen.tsx
+++ b/src/screens/GameScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -7,16 +7,31 @@ import {
   Alert,
   TouchableOpacity,
   Share,
+  AppState,
+  ActivityIndicator,
 } from 'react-native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RouteProp } from '@react-navigation/native';
 import { RootStackParamList } from '../types/navigation';
-import { GameState, PieceType } from '../types/game';
+import {
+  GameState,
+  PieceType,
+  normalizeBoard,
+  remainingPieces,
+  UIBoard,
+} from '../types/game';
 import { gotakAPI } from '../services/api';
 import { IsometricBoard } from '../components/IsometricBoard';
 import { PieceInventory } from '../components/PieceInventory';
-import { isAxiosError } from 'axios';
-import { logDebug, logException } from '../utils/logger';
+import { useAuth } from '../context/AuthContext';
+import {
+  buildPlacementPtn,
+  buildStackSlidePtn,
+  coordsToSquare,
+  directionBetween,
+  isAdjacent,
+} from '../utils/ptn';
+import { logException } from '../utils/logger';
 
 type GameScreenNavigationProp = StackNavigationProp<RootStackParamList, 'Game'>;
 type GameScreenRouteProp = RouteProp<RootStackParamList, 'Game'>;
@@ -27,74 +42,197 @@ interface Props {
 }
 
 export const GameScreen: React.FC<Props> = ({ navigation, route }) => {
+  const { user } = useAuth();
   const [gameState, setGameState] = useState<GameState | null>(null);
   const [loading, setLoading] = useState(true);
-  const [selectedPieceType, setSelectedPieceType] = useState<PieceType | undefined>(undefined);
+  const [selectedPieceType, setSelectedPieceType] = useState<PieceType | undefined>();
+  const [selectedStack, setSelectedStack] = useState<string | null>(null);
+  const [stackCount, setStackCount] = useState(1);
+  const [busy, setBusy] = useState(false);
+  const appActive = useRef(true);
+  const requestingAi = useRef(false);
 
-  const initializeGame = useCallback(async () => {
+  const board: UIBoard | null = useMemo(
+    () => (gameState ? normalizeBoard(gameState.Board) : null),
+    [gameState],
+  );
+
+  const myPlayer = useMemo(() => {
+    if (!gameState || !user) return null;
+    if (gameState.white_player_id === user.id) return 1;
+    if (gameState.black_player_id === user.id) return 2;
+    // AI games: creator is white and black_player_id is unset
+    if (gameState.mode === 'ai' && gameState.white_player_id === user.id) return 1;
+    return null;
+  }, [gameState, user]);
+
+  const currentTurnNumber = useMemo(() => {
+    if (!gameState?.Turns?.length) return 1;
+    const last = gameState.Turns[gameState.Turns.length - 1];
+    if (last.First && !last.Second) return last.Number;
+    return last.Number + 1;
+  }, [gameState]);
+
+  const canAct =
+    !!gameState &&
+    !!myPlayer &&
+    gameState.status !== 'finished' &&
+    gameState.current_player === myPlayer &&
+    (gameState.mode === 'ai' || gameState.status === 'active');
+
+  const inventory = useMemo(() => {
+    if (!board || !myPlayer) {
+      return { flat: 0, standing: 0, capstone: 0 };
+    }
+    return remainingPieces(board, myPlayer);
+  }, [board, myPlayer]);
+
+  const loadGame = useCallback(async () => {
+    const slug = route.params?.gameId;
+    if (!slug) {
+      Alert.alert('Error', 'Missing game id');
+      navigation.goBack();
+      return;
+    }
     try {
-      setLoading(true);
-      const gameSlug = route.params?.gameId;
-
-      // Test connection first
-      const isConnected = await gotakAPI.testConnection();
-      if (!isConnected) {
-        Alert.alert('Connection Error', 'Cannot connect to the game server. Please check your internet connection and try again.');
-        return;
-      }
-
-      let game: GameState;
-      if (gameSlug) {
-        game = await gotakAPI.getGame(gameSlug);
-      } else {
-        game = await gotakAPI.createGame(5);
-      }
-
-      logDebug('Game loaded', {
-        slug: game.slug,
-        boardSize: game.board.size,
-        squareCount: Object.keys(game.board.squares).length,
-        turnCount: game.turns?.length ?? 0,
-      });
-
+      const game = await gotakAPI.getGame(slug);
       setGameState(game);
     } catch (error) {
       logException(error instanceof Error ? error : new Error(String(error)), {
-        method: 'initializeGame',
+        method: 'loadGame',
       });
-
-      let errorMessage = 'Failed to initialize game';
-      if (isAxiosError(error)) {
-        const status = error.response?.status;
-        if (status === 404) {
-          errorMessage = 'Game not found. Please check the game ID.';
-        } else if (status && status >= 500) {
-          errorMessage = 'Server error. Please try again later.';
-        } else if (error.code === 'NETWORK_ERROR') {
-          errorMessage = 'Network error. Please check your internet connection.';
-        } else {
-          errorMessage = `Server error: ${status} - ${error.response?.data?.message || error.message}`;
-        }
-      }
-
-      Alert.alert('Error', errorMessage);
+      Alert.alert('Error', gotakAPI.formatError(error, 'Failed to load game'));
     } finally {
       setLoading(false);
     }
-  }, [route.params?.gameId]);
+  }, [navigation, route.params?.gameId]);
 
   useEffect(() => {
-    initializeGame();
-  }, [initializeGame]);
+    void loadGame();
+  }, [loadGame]);
+
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (next) => {
+      appActive.current = next === 'active';
+    });
+    return () => sub.remove();
+  }, []);
+
+  // Poll for opponent moves in human games
+  useEffect(() => {
+    if (!gameState || gameState.mode !== 'human') return;
+    if (gameState.status === 'finished') return;
+
+    const waitingForOpponent =
+      gameState.status === 'waiting' ||
+      (myPlayer != null && gameState.current_player !== myPlayer);
+
+    if (!waitingForOpponent) return;
+
+    const id = setInterval(() => {
+      if (!appActive.current) return;
+      void gotakAPI
+        .getGame(gameState.Slug)
+        .then(setGameState)
+        .catch((error) => {
+          logException(error instanceof Error ? error : new Error(String(error)), {
+            method: 'pollGame',
+          });
+        });
+    }, 2000);
+
+    return () => clearInterval(id);
+  }, [gameState, myPlayer]);
+
+  // Trigger AI move when it's the AI's turn
+  useEffect(() => {
+    if (!gameState || gameState.mode !== 'ai') return;
+    if (gameState.status === 'finished') return;
+    if (!myPlayer) return;
+    if (gameState.current_player === myPlayer) return;
+    if (requestingAi.current) return;
+
+    requestingAi.current = true;
+    void gotakAPI
+      .requestAiMove(gameState.Slug)
+      .then((updated) => setGameState(updated))
+      .catch((error) => {
+        Alert.alert('AI Error', gotakAPI.formatError(error, 'AI move failed'));
+      })
+      .finally(() => {
+        requestingAi.current = false;
+      });
+  }, [gameState, myPlayer]);
+
+  const submitMove = async (ptn: string) => {
+    if (!gameState || !myPlayer) return;
+    setBusy(true);
+    try {
+      const updated = await gotakAPI.makeMove(
+        gameState.Slug,
+        ptn,
+        myPlayer,
+        currentTurnNumber,
+      );
+      setGameState(updated);
+      setSelectedPieceType(undefined);
+      setSelectedStack(null);
+      setStackCount(1);
+    } catch (error) {
+      Alert.alert('Invalid move', gotakAPI.formatError(error, 'Move rejected'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleSquarePress = (x: number, y: number) => {
+    if (!board || !gameState || !myPlayer || !canAct || busy) return;
+    const square = coordsToSquare(x, y);
+    const stones = board.squares[square] || [];
+
+    // Placement
+    if (selectedPieceType) {
+      if (stones.length > 0) {
+        Alert.alert('Occupied', 'Choose an empty square to place a piece.');
+        return;
+      }
+      void submitMove(buildPlacementPtn(square, selectedPieceType));
+      return;
+    }
+
+    // Stack selection / slide
+    if (selectedStack) {
+      if (selectedStack === square) {
+        setSelectedStack(null);
+        return;
+      }
+      if (!isAdjacent(selectedStack, square)) {
+        Alert.alert('Stack move', 'Tap an orthogonally adjacent square.');
+        return;
+      }
+      const dir = directionBetween(selectedStack, square);
+      if (!dir) return;
+      void submitMove(buildStackSlidePtn(selectedStack, dir, stackCount));
+      return;
+    }
+
+    // Select own stack (top stone must be ours)
+    if (stones.length === 0) return;
+    const top = stones[stones.length - 1];
+    if (top.player !== myPlayer) return;
+    const maxCarry = Math.min(stones.length, board.size);
+    setSelectedStack(square);
+    setStackCount(maxCarry);
+    setSelectedPieceType(undefined);
+  };
 
   const handleShareGame = async () => {
     if (!gameState) return;
-
     try {
-      const gameLink = await gotakAPI.getGameLink(gameState.slug);
+      const link = gotakAPI.getGameLink(gameState.Slug);
       await Share.share({
-        message: `Join my Tak game: ${gameLink}`,
-        url: gameLink,
+        message: `Join my Tak game (${gameState.Slug}): ${link}`,
+        url: link,
       });
     } catch (error) {
       logException(error instanceof Error ? error : new Error(String(error)), {
@@ -103,166 +241,114 @@ export const GameScreen: React.FC<Props> = ({ navigation, route }) => {
     }
   };
 
-  const handlePlacePiece = async (x: number, y: number, pieceType: PieceType) => {
-    if (!gameState) {
-      logDebug('handlePlacePiece called with no game state');
-      return;
-    }
-
-    try {
-      // Convert grid coordinates to Tak square notation (e.g., "c3").
-      const file = String.fromCharCode(97 + x);
-      const rank = y + 1;
-      const square = `${file}${rank}`;
-
-      const currentTurn = (gameState.turns?.length || 0) + 1;
-      const currentPlayer = currentTurn % 2 === 1 ? 1 : 2;
-
-      let stoneType = 'flat';
-      if (pieceType === 'standing') {
-        stoneType = 'wall';
-      } else if (pieceType === 'capstone') {
-        stoneType = 'capstone';
-      }
-
-      logDebug('Placing piece', { square, currentPlayer, currentTurn, stoneType, pieceType });
-
-      const updatedGame = await gotakAPI.makeMove(
-        gameState.slug,
-        square,
-        currentPlayer,
-        currentTurn,
-        stoneType,
-      );
-
-      setGameState(updatedGame);
-      setSelectedPieceType(undefined);
-
-      // Server occasionally lags writing the move; refetch shortly after to settle state.
-      setTimeout(async () => {
-        try {
-          const refreshedGame = await gotakAPI.getGame(gameState.slug);
-          setGameState(refreshedGame);
-        } catch (error) {
-          logException(error instanceof Error ? error : new Error(String(error)), {
-            method: 'refreshGameAfterMove',
-            slug: gameState.slug,
-          });
-        }
-      }, 1000);
-    } catch (error) {
-      logException(error instanceof Error ? error : new Error(String(error)), {
-        method: 'handlePlacePiece',
-      });
-      Alert.alert('Error', 'Failed to place piece. Please try again.');
-    }
-  };
-
-  // Helper function to get current player color
-  const getCurrentPlayerColor = () => {
-    if (!gameState) return 'white';
-    const currentTurn = (gameState.turns?.length || 0) + 1;
-    return currentTurn % 2 === 1 ? 'white' : 'black';
-  };
-
-  // Helper function to get game status
-  const getGameStatus = () => {
-    if (!gameState) return 'loading';
-    if (!gameState.turns || gameState.turns.length === 0) return 'waiting';
-    const lastTurn = gameState.turns[gameState.turns.length - 1];
-    if (lastTurn.result) return 'finished';
-    return 'active';
-  };
-
   if (loading) {
     return (
       <SafeAreaView style={styles.container}>
-        <View style={styles.loadingContainer}>
+        <View style={styles.centered}>
+          <ActivityIndicator color="#fff" size="large" />
           <Text style={styles.loadingText}>Loading game...</Text>
         </View>
       </SafeAreaView>
     );
   }
 
-  if (!gameState) {
+  if (!gameState || !board) {
     return (
       <SafeAreaView style={styles.container}>
-        <View style={styles.errorContainer}>
-          <Text style={styles.errorText}>Failed to load game</Text>
-          <TouchableOpacity style={styles.retryButton} onPress={initializeGame}>
-            <Text style={styles.retryButtonText}>Retry</Text>
+        <View style={styles.centered}>
+          <Text style={styles.loadingText}>Failed to load game</Text>
+          <TouchableOpacity style={styles.shareButton} onPress={() => void loadGame()}>
+            <Text style={styles.shareButtonText}>Retry</Text>
           </TouchableOpacity>
         </View>
       </SafeAreaView>
     );
   }
 
+  const statusLabel =
+    gameState.status === 'finished'
+      ? `Finished — winner: ${gameState.winner === 1 ? 'White' : gameState.winner === 2 ? 'Black' : 'draw/flat'}`
+      : gameState.status === 'waiting'
+        ? 'Waiting for opponent'
+        : canAct
+          ? 'Your turn'
+          : 'Opponent turn';
+
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
-        <Text style={styles.gameTitle}>Tak Game</Text>
-        <TouchableOpacity style={styles.shareButton} onPress={handleShareGame}>
+        <TouchableOpacity onPress={() => navigation.goBack()}>
+          <Text style={styles.backText}>Back</Text>
+        </TouchableOpacity>
+        <Text style={styles.gameTitle}>{gameState.Slug}</Text>
+        <TouchableOpacity style={styles.shareButton} onPress={() => void handleShareGame()}>
           <Text style={styles.shareButtonText}>Share</Text>
         </TouchableOpacity>
       </View>
 
       <View style={styles.gameInfo}>
-        <Text style={styles.currentPlayer}>
-          Current Player: {getCurrentPlayerColor()}
+        <Text style={styles.infoText}>{statusLabel}</Text>
+        <Text style={styles.infoText}>
+          Mode: {gameState.mode} · You: {myPlayer === 1 ? 'White' : myPlayer === 2 ? 'Black' : '?'}
         </Text>
-        <Text style={styles.gameStatus}>
-          Status: {getGameStatus()}
+        <Text style={styles.infoText}>
+          Turn {currentTurnNumber} · To move: {gameState.current_player === 1 ? 'White' : 'Black'}
         </Text>
-        <Text style={styles.turnInfo}>
-          Turn: {(gameState.turns?.length || 0) + 1}
-        </Text>
-        <Text style={styles.debugInfo}>
-          Board Size: {gameState.board.size} | Squares: {Object.keys(gameState.board.squares).length}
-        </Text>
-        <Text style={styles.debugInfo}>
-          Sample Squares: {Object.keys(gameState.board.squares).slice(0, 3).join(', ')}
-        </Text>
+        {selectedStack ? (
+          <View style={styles.stackControls}>
+            <Text style={styles.infoText}>Moving {stackCount} from {selectedStack}</Text>
+            <View style={styles.stackButtons}>
+              <TouchableOpacity
+                style={styles.tinyButton}
+                onPress={() => setStackCount((c) => Math.max(1, c - 1))}
+              >
+                <Text style={styles.tinyButtonText}>-</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.tinyButton}
+                onPress={() => {
+                  const stones = board.squares[selectedStack] || [];
+                  const maxCarry = Math.min(stones.length, board.size);
+                  setStackCount((c) => Math.min(maxCarry, c + 1));
+                }}
+              >
+                <Text style={styles.tinyButtonText}>+</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={styles.tinyButton}
+                onPress={() => setSelectedStack(null)}
+              >
+                <Text style={styles.tinyButtonText}>Cancel</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        ) : null}
       </View>
 
       <View style={styles.gameArea}>
         <IsometricBoard
-          board={gameState.board}
+          board={board}
           selectedPieceType={selectedPieceType}
-          onSquarePress={(x, y) => {
-            if (selectedPieceType) {
-              handlePlacePiece(x, y, selectedPieceType);
-            }
-          }}
+          selectedSquare={selectedStack ?? undefined}
+          onSquarePress={handleSquarePress}
         />
 
         <PieceInventory
-          pieces={{
-            flat: 21, // Default piece counts for 5x5 board
-            standing: 1,
-            capstone: 1,
-          }}
-          color="white"
+          pieces={inventory}
+          color={myPlayer === 2 ? 'black' : 'white'}
           selectedPieceType={selectedPieceType}
-          onPieceSelect={(pieceType) => {
-            logDebug('Piece selected', { pieceType });
-            setSelectedPieceType(selectedPieceType === pieceType ? undefined : pieceType);
+          onPieceSelect={(type) => {
+            setSelectedPieceType(type);
+            setSelectedStack(null);
           }}
         />
-
-        {selectedPieceType && (
-          <View style={styles.selectedPieceIndicator}>
-            <Text style={styles.selectedPieceText}>
-              Selected: {selectedPieceType} piece
-            </Text>
-            <TouchableOpacity
-              style={styles.cancelButton}
-              onPress={() => setSelectedPieceType(undefined)}
-            >
-              <Text style={styles.cancelButtonText}>Cancel</Text>
-            </TouchableOpacity>
-          </View>
-        )}
       </View>
+
+      {busy ? (
+        <View style={styles.busyOverlay}>
+          <ActivityIndicator color="#fff" />
+        </View>
+      ) : null}
     </SafeAreaView>
   );
 };
@@ -272,22 +358,35 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: '#2c3e50',
   },
+  centered: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  loadingText: {
+    color: '#ecf0f1',
+    marginTop: 12,
+  },
   header: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    padding: 16,
-    borderBottomWidth: 1,
-    borderBottomColor: '#34495e',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  backText: {
+    color: '#3498db',
+    fontSize: 16,
   },
   gameTitle: {
-    fontSize: 24,
-    fontWeight: 'bold',
     color: '#ecf0f1',
+    fontSize: 16,
+    fontWeight: '600',
+    maxWidth: '50%',
   },
   shareButton: {
     backgroundColor: '#3498db',
-    paddingHorizontal: 16,
+    paddingHorizontal: 12,
     paddingVertical: 8,
     borderRadius: 6,
   },
@@ -296,85 +395,38 @@ const styles = StyleSheet.create({
     fontWeight: '600',
   },
   gameInfo: {
-    padding: 16,
-    backgroundColor: '#34495e',
+    paddingHorizontal: 16,
+    marginBottom: 8,
   },
-  currentPlayer: {
-    color: '#ecf0f1',
-    fontSize: 16,
-    marginBottom: 4,
-  },
-  gameStatus: {
+  infoText: {
     color: '#bdc3c7',
-    fontSize: 14,
-  },
-  turnInfo: {
-    color: '#ecf0f1',
-    fontSize: 14,
-    marginTop: 4,
+    marginBottom: 4,
   },
   gameArea: {
     flex: 1,
-    padding: 16,
+    paddingHorizontal: 8,
   },
-  loadingContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+  stackControls: {
+    marginTop: 8,
   },
-  loadingText: {
-    color: '#ecf0f1',
-    fontSize: 18,
-  },
-  errorContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  errorText: {
-    color: '#e74c3c',
-    fontSize: 18,
-    marginBottom: 16,
-  },
-  retryButton: {
-    backgroundColor: '#3498db',
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    borderRadius: 8,
-  },
-  retryButtonText: {
-    color: '#fff',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  selectedPieceIndicator: {
-    backgroundColor: '#34495e',
+  stackButtons: {
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: 12,
-    marginTop: 16,
-    borderRadius: 8,
-  },
-  selectedPieceText: {
-    color: '#ecf0f1',
-    fontSize: 16,
-    fontWeight: '600',
-  },
-  cancelButton: {
-    backgroundColor: '#e74c3c',
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    borderRadius: 6,
-  },
-  cancelButtonText: {
-    color: '#fff',
-    fontSize: 14,
-    fontWeight: '600',
-  },
-  debugInfo: {
-    color: '#95a5a6',
-    fontSize: 12,
     marginTop: 4,
+  },
+  tinyButton: {
+    backgroundColor: '#34495e',
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 6,
+    marginRight: 8,
+  },
+  tinyButtonText: {
+    color: '#ecf0f1',
+  },
+  busyOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.25)',
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 });

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,14 +1,19 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   View,
   Text,
   StyleSheet,
   TouchableOpacity,
   SafeAreaView,
+  TextInput,
+  Alert,
+  ActivityIndicator,
 } from 'react-native';
 import { StackNavigationProp } from '@react-navigation/stack';
 import { RootStackParamList } from '../types/navigation';
-import { logDebug } from '../utils/logger';
+import { useAuth } from '../context/AuthContext';
+import { gotakAPI } from '../services/api';
+import { GameMode } from '../types/game';
 
 type HomeScreenNavigationProp = StackNavigationProp<RootStackParamList, 'Home'>;
 
@@ -16,14 +21,46 @@ interface Props {
   navigation: HomeScreenNavigationProp;
 }
 
+const BOARD_SIZES = [4, 5, 6, 7, 8];
+
 export const HomeScreen: React.FC<Props> = ({ navigation }) => {
-  const handleNewGame = () => {
-    navigation.navigate('Game', {});
+  const { user, logout } = useAuth();
+  const [boardSize, setBoardSize] = useState(5);
+  const [joinSlug, setJoinSlug] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const startGame = async (mode: GameMode) => {
+    setBusy(true);
+    try {
+      const connected = await gotakAPI.testConnection();
+      if (!connected) {
+        Alert.alert('Connection Error', 'Cannot reach the game server.');
+        return;
+      }
+      const game = await gotakAPI.createGame(boardSize, mode);
+      navigation.navigate('Game', { gameId: game.Slug, mode });
+    } catch (error) {
+      Alert.alert('Error', gotakAPI.formatError(error, 'Failed to create game'));
+    } finally {
+      setBusy(false);
+    }
   };
 
-  const handleJoinGame = () => {
-    // TODO: Implement join game flow
-    logDebug('Join game pressed');
+  const handleJoin = async () => {
+    const slug = joinSlug.trim();
+    if (!slug) {
+      Alert.alert('Join Game', 'Enter a game slug to join.');
+      return;
+    }
+    setBusy(true);
+    try {
+      await gotakAPI.joinGame(slug);
+      navigation.navigate('Game', { gameId: slug, mode: 'human' });
+    } catch (error) {
+      Alert.alert('Error', gotakAPI.formatError(error, 'Failed to join game'));
+    } finally {
+      setBusy(false);
+    }
   };
 
   return (
@@ -31,20 +68,68 @@ export const HomeScreen: React.FC<Props> = ({ navigation }) => {
       <View style={styles.content}>
         <Text style={styles.title}>Tak</Text>
         <Text style={styles.subtitle}>The Beautiful Game</Text>
+        <Text style={styles.userLine}>Signed in as {user?.name || user?.email}</Text>
 
-        <View style={styles.buttonContainer}>
-          <TouchableOpacity style={styles.button} onPress={handleNewGame}>
-            <Text style={styles.buttonText}>New Game</Text>
-          </TouchableOpacity>
-
-          <TouchableOpacity style={styles.button} onPress={handleJoinGame}>
-            <Text style={styles.buttonText}>Join Game</Text>
-          </TouchableOpacity>
+        <Text style={styles.sectionLabel}>Board size</Text>
+        <View style={styles.sizeRow}>
+          {BOARD_SIZES.map((size) => (
+            <TouchableOpacity
+              key={size}
+              style={[styles.sizeChip, boardSize === size && styles.sizeChipActive]}
+              onPress={() => setBoardSize(size)}
+            >
+              <Text
+                style={[
+                  styles.sizeChipText,
+                  boardSize === size && styles.sizeChipTextActive,
+                ]}
+              >
+                {size}
+              </Text>
+            </TouchableOpacity>
+          ))}
         </View>
 
-        <Text style={styles.description}>
-          Tak is a two-player board game where you build roads of stones to connect opposite sides of the board.
-        </Text>
+        <TouchableOpacity
+          style={[styles.button, busy && styles.buttonDisabled]}
+          onPress={() => startGame('human')}
+          disabled={busy}
+        >
+          <Text style={styles.buttonText}>New vs Human</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.button, styles.buttonSecondary, busy && styles.buttonDisabled]}
+          onPress={() => startGame('ai')}
+          disabled={busy}
+        >
+          <Text style={styles.buttonText}>New vs AI</Text>
+        </TouchableOpacity>
+
+        <Text style={styles.sectionLabel}>Join by slug</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="game-slug"
+          placeholderTextColor="#95a5a6"
+          autoCapitalize="none"
+          value={joinSlug}
+          onChangeText={setJoinSlug}
+        />
+        <TouchableOpacity
+          style={[styles.button, styles.buttonJoin, busy && styles.buttonDisabled]}
+          onPress={handleJoin}
+          disabled={busy}
+        >
+          {busy ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.buttonText}>Join Game</Text>
+          )}
+        </TouchableOpacity>
+
+        <TouchableOpacity style={styles.logout} onPress={() => void logout()}>
+          <Text style={styles.logoutText}>Sign out</Text>
+        </TouchableOpacity>
       </View>
     </SafeAreaView>
   );
@@ -58,40 +143,89 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     justifyContent: 'center',
-    alignItems: 'center',
     padding: 20,
   },
   title: {
     fontSize: 48,
     fontWeight: 'bold',
     color: '#ecf0f1',
+    textAlign: 'center',
     marginBottom: 8,
   },
   subtitle: {
     fontSize: 18,
     color: '#bdc3c7',
-    marginBottom: 40,
+    textAlign: 'center',
+    marginBottom: 8,
   },
-  buttonContainer: {
-    width: '100%',
-    marginBottom: 40,
+  userLine: {
+    color: '#95a5a6',
+    textAlign: 'center',
+    marginBottom: 24,
+  },
+  sectionLabel: {
+    color: '#bdc3c7',
+    marginBottom: 8,
+    marginTop: 8,
+  },
+  sizeRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 20,
+  },
+  sizeChip: {
+    flex: 1,
+    marginHorizontal: 4,
+    paddingVertical: 10,
+    borderRadius: 8,
+    backgroundColor: '#34495e',
+    alignItems: 'center',
+  },
+  sizeChipActive: {
+    backgroundColor: '#3498db',
+  },
+  sizeChipText: {
+    color: '#bdc3c7',
+    fontWeight: '600',
+  },
+  sizeChipTextActive: {
+    color: '#fff',
+  },
+  input: {
+    backgroundColor: '#34495e',
+    color: '#ecf0f1',
+    borderRadius: 8,
+    padding: 14,
+    marginBottom: 12,
+    fontSize: 16,
   },
   button: {
     backgroundColor: '#3498db',
     padding: 16,
     borderRadius: 8,
-    marginBottom: 16,
+    marginBottom: 12,
     alignItems: 'center',
+  },
+  buttonSecondary: {
+    backgroundColor: '#9b59b6',
+  },
+  buttonJoin: {
+    backgroundColor: '#27ae60',
+  },
+  buttonDisabled: {
+    opacity: 0.6,
   },
   buttonText: {
     color: '#fff',
     fontSize: 18,
     fontWeight: '600',
   },
-  description: {
-    fontSize: 14,
-    color: '#95a5a6',
-    textAlign: 'center',
-    lineHeight: 20,
+  logout: {
+    marginTop: 24,
+    alignItems: 'center',
+  },
+  logoutText: {
+    color: '#e74c3c',
+    fontSize: 16,
   },
 });

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -1,0 +1,171 @@
+import React, { useState } from 'react';
+import {
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  SafeAreaView,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { useAuth } from '../context/AuthContext';
+import { gotakAPI } from '../services/api';
+
+export const LoginScreen: React.FC = () => {
+  const { login, register } = useAuth();
+  const [mode, setMode] = useState<'login' | 'register'>('login');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const onSubmit = async () => {
+    setError(null);
+    setBusy(true);
+    try {
+      if (mode === 'login') {
+        await login(email, password);
+      } else {
+        await register(email, password, name || email.split('@')[0]);
+      }
+    } catch (err) {
+      setError(gotakAPI.formatError(err, 'Authentication failed'));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.content}
+      >
+        <Text style={styles.title}>Tak</Text>
+        <Text style={styles.subtitle}>
+          {mode === 'login' ? 'Sign in to play' : 'Create an account'}
+        </Text>
+
+        {mode === 'register' && (
+          <TextInput
+            style={styles.input}
+            placeholder="Name"
+            placeholderTextColor="#95a5a6"
+            autoCapitalize="words"
+            value={name}
+            onChangeText={setName}
+          />
+        )}
+
+        <TextInput
+          style={styles.input}
+          placeholder="Email"
+          placeholderTextColor="#95a5a6"
+          autoCapitalize="none"
+          keyboardType="email-address"
+          autoComplete="email"
+          value={email}
+          onChangeText={setEmail}
+        />
+
+        <TextInput
+          style={styles.input}
+          placeholder="Password"
+          placeholderTextColor="#95a5a6"
+          secureTextEntry
+          value={password}
+          onChangeText={setPassword}
+        />
+
+        {error ? <Text style={styles.error}>{error}</Text> : null}
+
+        <TouchableOpacity
+          style={[styles.button, busy && styles.buttonDisabled]}
+          onPress={onSubmit}
+          disabled={busy || !email || password.length < 8}
+        >
+          {busy ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.buttonText}>
+              {mode === 'login' ? 'Sign In' : 'Create Account'}
+            </Text>
+          )}
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() => {
+            setMode(mode === 'login' ? 'register' : 'login');
+            setError(null);
+          }}
+        >
+          <Text style={styles.switchText}>
+            {mode === 'login'
+              ? 'Need an account? Register'
+              : 'Already have an account? Sign in'}
+          </Text>
+        </TouchableOpacity>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#2c3e50',
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 24,
+  },
+  title: {
+    fontSize: 48,
+    fontWeight: 'bold',
+    color: '#ecf0f1',
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#bdc3c7',
+    textAlign: 'center',
+    marginBottom: 32,
+  },
+  input: {
+    backgroundColor: '#34495e',
+    color: '#ecf0f1',
+    borderRadius: 8,
+    padding: 14,
+    marginBottom: 12,
+    fontSize: 16,
+  },
+  button: {
+    backgroundColor: '#3498db',
+    padding: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginTop: 8,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  switchText: {
+    color: '#bdc3c7',
+    textAlign: 'center',
+    marginTop: 20,
+  },
+  error: {
+    color: '#e74c3c',
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+});

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,121 +1,102 @@
 import axios, { isAxiosError } from 'axios';
-import { GameState } from '../types/game';
+import type { AxiosInstance } from 'axios';
 import { API_CONFIG } from '../config/api';
+import { AuthResponse, AuthUser, GameMode, GameState } from '../types/game';
 import { logDebug, logError, logException } from '../utils/logger';
 
+type UnauthorizedHandler = () => void;
+
 class GotakAPI {
-  private client = axios.create({
-    baseURL: API_CONFIG.BASE_URL,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    timeout: API_CONFIG.TIMEOUT,
-  });
+  private client: AxiosInstance;
+  private token: string | null = null;
+  private onUnauthorized: UnauthorizedHandler | null = null;
+
+  constructor() {
+    // eslint-disable-next-line import/no-named-as-default-member -- axios.create is the documented factory
+    this.client = axios.create({
+      baseURL: API_CONFIG.BASE_URL,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      timeout: API_CONFIG.TIMEOUT,
+    });
+
+    this.client.interceptors.request.use((config) => {
+      if (this.token) {
+        config.headers.Authorization = `Bearer ${this.token}`;
+      }
+      return config;
+    });
+
+    this.client.interceptors.response.use(
+      (response) => response,
+      (error) => {
+        if (isAxiosError(error) && error.response?.status === 401) {
+          this.onUnauthorized?.();
+        }
+        return Promise.reject(error);
+      },
+    );
+  }
+
+  setToken(token: string | null) {
+    this.token = token;
+  }
+
+  setUnauthorizedHandler(handler: UnauthorizedHandler | null) {
+    this.onUnauthorized = handler;
+  }
 
   async testConnection(): Promise<boolean> {
     try {
-      logDebug('Testing connection', { baseUrl: API_CONFIG.BASE_URL });
-      const response = await this.client.get('/');
-      logDebug('Server is reachable', { status: response.status });
-      return true;
+      const response = await this.client.get('/healthz');
+      return response.status === 200;
     } catch (error) {
-      logException(
-        error instanceof Error ? error : new Error(String(error)),
-        { method: 'testConnection' },
-      );
+      logException(error instanceof Error ? error : new Error(String(error)), {
+        method: 'testConnection',
+      });
       return false;
     }
   }
 
-  async createGame(boardSize: number = 5): Promise<GameState> {
-    try {
-      logDebug('Creating game', { boardSize });
-      const response = await this.client.post('/game/new', {
-        // API expects size as string
-        size: boardSize.toString(),
-      });
-      const apiData = response.data;
-      logDebug('Game created', { id: apiData.ID, slug: apiData.Slug });
+  async register(email: string, password: string, name: string): Promise<void> {
+    await this.client.post('/auth/register', { email, password, name });
+  }
 
-      // For new games the board is empty so we trust the server's state.
-      return {
-        id: apiData.ID,
-        slug: apiData.Slug,
-        board: {
-          size: apiData.Board.Size,
-          squares: apiData.Board.Squares,
-        },
-        turns: apiData.Turns || [],
-        meta: apiData.Meta || [],
-      };
-    } catch (error) {
-      if (isAxiosError(error)) {
-        logError('Error creating game', {
-          status: error.response?.status,
-          code: error.code,
-          message: error.message,
-        });
-      } else {
-        logException(error instanceof Error ? error : new Error(String(error)), {
-          method: 'createGame',
-        });
-      }
-      throw error;
-    }
+  async login(email: string, password: string): Promise<AuthResponse> {
+    const response = await this.client.post<AuthResponse>('/auth/login', {
+      email,
+      password,
+    });
+    return {
+      token: response.data.token,
+      user: this.normalizeUser(response.data.user),
+    };
+  }
+
+  async getProfile(): Promise<AuthUser> {
+    const response = await this.client.get('/auth/profile');
+    return this.normalizeUser(response.data);
+  }
+
+  async createGame(boardSize: number, mode: GameMode = 'human'): Promise<GameState> {
+    logDebug('Creating game', { boardSize, mode });
+    const response = await this.client.post(
+      '/game/new',
+      { size: boardSize.toString(), mode },
+      { headers: { Accept: 'application/json' } },
+    );
+    return this.normalizeGame(response.data);
+  }
+
+  async joinGame(slug: string): Promise<void> {
+    await this.client.post(`/game/${slug}/join`);
   }
 
   async getGame(slug: string): Promise<GameState> {
     const response = await this.client.get(`/game/${slug}`);
-    const apiData = response.data;
-
-    // Server stores moves but does not maintain board state, so reconstruct.
-    const reconstructedBoard = this.reconstructBoardFromMoves(
-      apiData.Turns || [],
-      apiData.Board.Size,
-    );
-    logDebug('Reconstructed board in getGame', { slug, size: apiData.Board.Size });
-
-    return {
-      id: apiData.ID,
-      slug: apiData.Slug,
-      board: {
-        size: apiData.Board.Size,
-        squares: reconstructedBoard,
-      },
-      turns: apiData.Turns || [],
-      meta: apiData.Meta || [],
-    };
-  }
-
-  private reconstructBoardFromMoves(turns: any[], boardSize: number): { [key: string]: any[] } {
-    const board: { [key: string]: any[] } = {};
-
-    for (let y = 1; y <= boardSize; y++) {
-      for (let x = 0; x < boardSize; x++) {
-        const file = String.fromCharCode(97 + x);
-        const square = `${file}${y}`;
-        board[square] = [];
-      }
-    }
-
-    turns.forEach((turn) => {
-      if (turn.First) {
-        const square = turn.First.Square;
-        const stoneType =
-          turn.First.Stone === 'F' ? 'flat' : turn.First.Stone === 'S' ? 'standing' : 'capstone';
-        const player = 1;
-        board[square].push({ player, type: stoneType });
-      }
-      if (turn.Second) {
-        const square = turn.Second.Square;
-        const stoneType =
-          turn.Second.Stone === 'F' ? 'flat' : turn.Second.Stone === 'S' ? 'standing' : 'capstone';
-        const player = 2;
-        board[square].push({ player, type: stoneType });
-      }
-    });
-
-    return board;
+    return this.normalizeGame(response.data);
   }
 
   async makeMove(
@@ -123,45 +104,80 @@ class GotakAPI {
     move: string,
     player: number,
     turn: number,
-    stoneType: string = 'flat',
   ): Promise<GameState> {
-    logDebug('Making move', { slug, move, player, turn, stoneType });
-
-    // Per gotak server docs the request only carries the square and player.
-    // Stone type is derived server-side from game logic.
-    const moveData = {
+    logDebug('Making move', { slug, move, player, turn });
+    const response = await this.client.post(`/game/${slug}/move`, {
       player,
       move,
       turn,
+    });
+    return this.normalizeGame(response.data);
+  }
+
+  async requestAiMove(
+    slug: string,
+    level = 'intermediate',
+    style = 'balanced',
+    timeLimitNs = 10_000_000_000,
+  ): Promise<GameState> {
+    const response = await this.client.post(`/game/${slug}/ai-move`, {
+      level,
+      style,
+      time_limit: timeLimitNs,
+    });
+    return this.normalizeGame(response.data);
+  }
+
+  getGameLink(slug: string): string {
+    return `${API_CONFIG.BASE_URL}/game/${slug}`;
+  }
+
+  private normalizeUser(raw: any): AuthUser {
+    return {
+      id: raw.id ?? raw.ID,
+      email: raw.email ?? raw.Email ?? '',
+      name: raw.name ?? raw.Name ?? '',
     };
+  }
 
-    const response = await this.client.post(`/game/${slug}/move`, moveData);
-    const apiData = response.data;
+  private normalizeGame(raw: any): GameState {
+    if (!raw) {
+      throw new Error('empty game response');
+    }
 
-    const reconstructedBoard = this.reconstructBoardFromMoves(
-      apiData.Turns || [],
-      apiData.Board.Size,
-    );
+    const board = raw.Board ?? raw.board;
+    if (!board) {
+      throw new Error('game response missing board');
+    }
 
     return {
-      id: apiData.ID,
-      slug: apiData.Slug,
-      board: {
-        size: apiData.Board.Size,
-        squares: reconstructedBoard,
+      ID: raw.ID ?? raw.id,
+      Slug: raw.Slug ?? raw.slug,
+      Board: {
+        Size: board.Size ?? board.size,
+        Squares: board.Squares ?? board.squares ?? {},
       },
-      turns: apiData.Turns || [],
-      meta: apiData.Meta || [],
+      Turns: raw.Turns ?? raw.turns ?? [],
+      Meta: raw.Meta ?? raw.meta ?? [],
+      current_player: raw.current_player ?? 1,
+      status: raw.status ?? 'waiting',
+      winner: raw.winner ?? 0,
+      white_player_id: raw.white_player_id,
+      black_player_id: raw.black_player_id,
+      mode: (raw.mode as GameMode) || 'human',
     };
   }
 
-  async getGameAtTurn(slug: string, turn: number): Promise<any> {
-    const response = await this.client.get(`/game/${slug}/${turn}`);
-    return response.data;
-  }
-
-  async getGameLink(slug: string): Promise<string> {
-    return `${API_CONFIG.BASE_URL}/game/${slug}`;
+  formatError(error: unknown, fallback: string): string {
+    if (isAxiosError(error)) {
+      const data = error.response?.data as { error?: string; message?: string } | undefined;
+      return data?.error || data?.message || error.message || fallback;
+    }
+    if (error instanceof Error) {
+      return error.message;
+    }
+    logError(fallback, { error: String(error) });
+    return fallback;
   }
 }
 

--- a/src/services/authStorage.ts
+++ b/src/services/authStorage.ts
@@ -1,0 +1,53 @@
+import * as SecureStore from 'expo-secure-store';
+import { AuthUser } from '../types/game';
+import { logError, logInfo } from '../utils/logger';
+
+const TOKEN_KEY = 'gotak_auth_token';
+const USER_KEY = 'gotak_auth_user';
+
+export interface StoredAuth {
+  token: string;
+  user: AuthUser;
+}
+
+export async function getStoredAuth(): Promise<StoredAuth | null> {
+  try {
+    const token = await SecureStore.getItemAsync(TOKEN_KEY);
+    const userJson = await SecureStore.getItemAsync(USER_KEY);
+    if (!token || !userJson) {
+      return null;
+    }
+    const user = JSON.parse(userJson) as AuthUser;
+    return { token, user };
+  } catch (error) {
+    logError('Failed to read stored auth', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+export async function setStoredAuth(token: string, user: AuthUser): Promise<void> {
+  try {
+    await SecureStore.setItemAsync(TOKEN_KEY, token);
+    await SecureStore.setItemAsync(USER_KEY, JSON.stringify(user));
+    logInfo('Auth credentials stored');
+  } catch (error) {
+    logError('Failed to store auth', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}
+
+export async function clearStoredAuth(): Promise<void> {
+  try {
+    await SecureStore.deleteItemAsync(TOKEN_KEY);
+    await SecureStore.deleteItemAsync(USER_KEY);
+    logInfo('Auth credentials cleared');
+  } catch (error) {
+    logError('Failed to clear auth', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,91 +1,156 @@
 export type PieceType = 'flat' | 'standing' | 'capstone';
 export type PlayerColor = 'white' | 'black';
+export type GameMode = 'human' | 'ai';
 
 export interface Stone {
+  Player: number;
+  Type: string;
+  // Lowercase aliases tolerated when mapping from older payloads
+  player?: number;
+  type?: string;
+}
+
+export interface Board {
+  Size: number;
+  Squares: { [key: string]: Stone[] };
+  // Lowercase aliases for convenience after normalize
+  size?: number;
+  squares?: { [key: string]: Stone[] };
+}
+
+export interface Move {
+  Square?: string;
+  Stone?: string;
+  Text?: string;
+  MoveCount?: number;
+  MoveDirection?: string;
+  MoveDropCounts?: number[];
+}
+
+export interface Turn {
+  Comment?: string;
+  First?: Move;
+  Number: number;
+  Result?: string;
+  Second?: Move;
+}
+
+export interface Tag {
+  Key: string;
+  Value: string;
+}
+
+export interface GameState {
+  ID: number;
+  Slug: string;
+  Board: Board;
+  Turns: Turn[];
+  Meta: Tag[];
+  current_player: number;
+  status: string;
+  winner: number;
+  white_player_id?: number;
+  black_player_id?: number;
+  mode: GameMode;
+}
+
+export interface AuthUser {
+  id: number;
+  email: string;
+  name: string;
+}
+
+export interface AuthResponse {
+  token: string;
+  user: AuthUser;
+}
+
+/** Normalized board view used by UI components. */
+export interface UIBoard {
+  size: number;
+  squares: { [key: string]: UIStone[] };
+}
+
+export interface UIStone {
   player: number;
   type: string;
 }
 
-export interface Board {
-  size: number;
-  squares: { [key: string]: Stone[] };
-}
-
-export interface Move {
-  moveCount?: number;
-  moveDirection?: string;
-  moveDropCounts?: number[];
-  square: string;
-  stone: string;
-  text: string;
-}
-
-export interface Turn {
-  comment?: string;
-  first: Move;
-  number: number;
-  result?: string;
-  second?: Move;
-}
-
-export interface Tag {
-  key: string;
-  value: string;
-}
-
-export interface GameState {
-  id: number;
-  slug: string;
-  board: Board;
-  turns: Turn[];
-  meta: Tag[];
-}
-
-// Legacy types for backward compatibility with UI components
-export interface Piece {
-  id: string;
-  type: PieceType;
-  color: PlayerColor;
-  position?: Position;
-}
-
-export interface Position {
-  x: number;
-  y: number;
-  stackIndex: number;
-}
-
-export interface Square {
-  pieces: Piece[];
-  x: number;
-  y: number;
-}
-
-export interface PlayerInfo {
-  id: string;
-  name: string;
-  pieces: {
-    flat: number;
-    standing: number;
-    capstone: number;
+export function normalizeStone(stone: Stone): UIStone {
+  return {
+    player: stone.Player ?? stone.player ?? 0,
+    type: (stone.Type ?? stone.type ?? 'F').toUpperCase(),
   };
 }
 
-export interface LegacyGameState {
-  id: string;
-  board: Board;
-  currentPlayer: PlayerColor;
-  players: {
-    white: PlayerInfo;
-    black: PlayerInfo;
-  };
-  gameStatus: 'waiting' | 'active' | 'finished';
-  winner?: PlayerColor;
+export function normalizeBoard(board: Board): UIBoard {
+  const size = board.Size ?? board.size ?? 5;
+  const raw = board.Squares ?? board.squares ?? {};
+  const squares: { [key: string]: UIStone[] } = {};
+  for (const [key, stones] of Object.entries(raw)) {
+    squares[key] = (stones || []).map(normalizeStone);
+  }
+  return { size, squares };
 }
 
-export interface LegacyMove {
-  from?: Position;
-  to: Position;
-  piece: Piece;
-  moveType: 'place' | 'move' | 'stack';
+export function maxFlatsForSize(size: number): number {
+  switch (size) {
+    case 3:
+      return 10;
+    case 4:
+      return 15;
+    case 5:
+      return 21;
+    case 6:
+      return 30;
+    case 7:
+      return 40;
+    case 8:
+    case 9:
+      return 50;
+    default:
+      return 21;
+  }
+}
+
+export function maxCapsForSize(size: number): number {
+  switch (size) {
+    case 3:
+    case 4:
+      return 0;
+    case 5:
+    case 6:
+    case 7:
+      return 1;
+    case 8:
+    case 9:
+      return 2;
+    default:
+      return 1;
+  }
+}
+
+export function remainingPieces(
+  board: UIBoard,
+  player: number,
+): { flat: number; standing: number; capstone: number } {
+  let usedFlats = 0;
+  let usedCaps = 0;
+  for (const stones of Object.values(board.squares)) {
+    for (const stone of stones) {
+      if (stone.player !== player) continue;
+      if (stone.type === 'C') {
+        usedCaps += 1;
+      } else {
+        usedFlats += 1;
+      }
+    }
+  }
+  const flats = Math.max(0, maxFlatsForSize(board.size) - usedFlats);
+  const caps = Math.max(0, maxCapsForSize(board.size) - usedCaps);
+  return {
+    flat: flats,
+    standing: flats,
+    capstone: caps,
+  };
 }

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,6 +1,8 @@
 export type RootStackParamList = {
+  Login: undefined;
   Home: undefined;
   Game: {
     gameId?: string;
+    mode?: 'human' | 'ai';
   };
 };

--- a/src/utils/__tests__/inventory.test.ts
+++ b/src/utils/__tests__/inventory.test.ts
@@ -1,0 +1,30 @@
+import { maxCapsForSize, maxFlatsForSize, remainingPieces } from '../../types/game';
+
+describe('inventory helpers', () => {
+  it('returns stone limits by size', () => {
+    expect(maxFlatsForSize(5)).toBe(21);
+    expect(maxCapsForSize(5)).toBe(1);
+    expect(maxCapsForSize(8)).toBe(2);
+  });
+
+  it('counts remaining pieces from board', () => {
+    const board = {
+      size: 5,
+      squares: {
+        a1: [{ player: 1, type: 'F' }],
+        b2: [{ player: 1, type: 'C' }],
+        c3: [{ player: 2, type: 'F' }],
+      },
+    };
+    expect(remainingPieces(board, 1)).toEqual({
+      flat: 20,
+      standing: 20,
+      capstone: 0,
+    });
+    expect(remainingPieces(board, 2)).toEqual({
+      flat: 20,
+      standing: 20,
+      capstone: 1,
+    });
+  });
+});

--- a/src/utils/__tests__/ptn.test.ts
+++ b/src/utils/__tests__/ptn.test.ts
@@ -1,0 +1,35 @@
+import {
+  buildPlacementPtn,
+  buildStackSlidePtn,
+  coordsToSquare,
+  directionBetween,
+  isAdjacent,
+  squareToCoords,
+} from '../ptn';
+
+describe('ptn helpers', () => {
+  it('builds placement PTN', () => {
+    expect(buildPlacementPtn('c3', 'flat')).toBe('c3');
+    expect(buildPlacementPtn('c3', 'standing')).toBe('Sc3');
+    expect(buildPlacementPtn('c3', 'capstone')).toBe('Cc3');
+  });
+
+  it('converts coordinates', () => {
+    expect(coordsToSquare(0, 0)).toBe('a1');
+    expect(coordsToSquare(2, 4)).toBe('c5');
+    expect(squareToCoords('c5')).toEqual({ x: 2, y: 4 });
+  });
+
+  it('detects adjacency and direction', () => {
+    expect(directionBetween('a1', 'b1')).toBe('>');
+    expect(directionBetween('b1', 'a1')).toBe('<');
+    expect(directionBetween('a1', 'a2')).toBe('+');
+    expect(directionBetween('a2', 'a1')).toBe('-');
+    expect(isAdjacent('a1', 'c1')).toBe(false);
+  });
+
+  it('builds stack slide PTN', () => {
+    expect(buildStackSlidePtn('a1', '>', 1)).toBe('a1>');
+    expect(buildStackSlidePtn('a1', '>', 3)).toBe('3a1>3');
+  });
+});

--- a/src/utils/ptn.ts
+++ b/src/utils/ptn.ts
@@ -1,0 +1,61 @@
+import { PieceType } from '../types/game';
+
+/** Build a placement PTN string: a1 / Sa1 / Ca1 */
+export function buildPlacementPtn(square: string, pieceType: PieceType): string {
+  switch (pieceType) {
+    case 'standing':
+      return `S${square}`;
+    case 'capstone':
+      return `C${square}`;
+    case 'flat':
+    default:
+      return square;
+  }
+}
+
+export type Direction = '>' | '<' | '+' | '-';
+
+export function coordsToSquare(x: number, y: number): string {
+  return `${String.fromCharCode(97 + x)}${y + 1}`;
+}
+
+export function squareToCoords(square: string): { x: number; y: number } | null {
+  const match = /^([a-z])(\d+)$/.exec(square.toLowerCase());
+  if (!match) return null;
+  return {
+    x: match[1].charCodeAt(0) - 97,
+    y: parseInt(match[2], 10) - 1,
+  };
+}
+
+export function directionBetween(
+  from: string,
+  to: string,
+): Direction | null {
+  const a = squareToCoords(from);
+  const b = squareToCoords(to);
+  if (!a || !b) return null;
+  const dx = b.x - a.x;
+  const dy = b.y - a.y;
+  if (dx === 1 && dy === 0) return '>';
+  if (dx === -1 && dy === 0) return '<';
+  if (dx === 0 && dy === 1) return '+';
+  if (dx === 0 && dy === -1) return '-';
+  return null;
+}
+
+/** Build a stack slide that drops all picked stones on the next square. */
+export function buildStackSlidePtn(
+  fromSquare: string,
+  direction: Direction,
+  count: number,
+): string {
+  if (count <= 1) {
+    return `${fromSquare}${direction}`;
+  }
+  return `${count}${fromSquare}${direction}${count}`;
+}
+
+export function isAdjacent(from: string, to: string): boolean {
+  return directionBetween(from, to) !== null;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true
-  }
+  },
+  "exclude": ["**/__tests__/**", "node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6515,15 +6515,15 @@ react-native-reanimated@4.2.2:
     react-native-is-edge-to-edge "1.2.1"
     semver "7.7.3"
 
-react-native-safe-area-context@^5.8.0:
-  version "5.8.0"
-  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.8.0.tgz#d2fb9fc8e0f0583311e261dc484b95ceb80f8902"
-  integrity sha512-t+ZsAVzY/wWzzx34vqGbo3/as9EEESJdbyZNL7Yg5EYX+toYMtMqFoDDCvqZUi35eeGVsXc6pAaEk4edMwbuCQ==
+react-native-safe-area-context@~5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz#283e006f5b434fb247fcb4be0971ad7473d5c560"
+  integrity sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==
 
-react-native-screens@^4.26.2:
-  version "4.26.2"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.26.2.tgz#cfc007736526a0958e8e8d3ff5f77202c323a852"
-  integrity sha512-2XnWsZToKj76trGtEZzx5ELD/qOICFEprEeUntImmitQFVUkea27fiWdUSITArI356Y1qynpXZINW+Unbhky/A==
+react-native-screens@~4.23.0:
+  version "4.23.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.23.0.tgz#81574b1b0cc4ac6c9ed63e46eca7126f37affe86"
+  integrity sha512-XhO3aK0UeLpBn4kLecd+J+EDeRRJlI/Ro9Fze06vo1q163VeYtzfU9QS09/VyDFMWR1qxDC1iazCArTPSFFiPw==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.12.13", "@babel/code-frame@^7.20.0", "@babel/code-frame@^7.29.0", "@babel/code-frame@^7.29.7":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.20.0", "@babel/code-frame@^7.27.1", "@babel/code-frame@^7.29.0", "@babel/code-frame@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.7.tgz#f2fbbfea87c44a21590ec515b778b2c26d8866e7"
   integrity sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==
@@ -21,7 +21,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.29.7.tgz#6f0237f0f36d2e51c0570a636faed9d2d0efe629"
   integrity sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==
 
-"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.20.0", "@babel/core@^7.25.2", "@babel/core@^7.29.7":
+"@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.20.0", "@babel/core@^7.23.9", "@babel/core@^7.25.2", "@babel/core@^7.27.4", "@babel/core@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.7.tgz#80c10b17248082968b57a857b91640971f2070f7"
   integrity sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==
@@ -42,7 +42,7 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
-"@babel/generator@^7.20.5", "@babel/generator@^7.29.1", "@babel/generator@^7.29.7":
+"@babel/generator@^7.20.5", "@babel/generator@^7.27.5", "@babel/generator@^7.29.1", "@babel/generator@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.7.tgz#cca0b8827e6bcf3ba176788e7f3b180ad6db2fa3"
   integrity sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==
@@ -159,6 +159,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz#6f13ea251b68c8532e985fd532f28741a8af9ac8"
   integrity sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==
 
+"@babel/helper-plugin-utils@^7.29.7":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz#c0a0766f1a13617d8a17407d7ab8f9d486225ea4"
+  integrity sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==
+
 "@babel/helper-remap-async-to-generator@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz#4601d5c7ce2eb2aea58328d43725523fcd362ce6"
@@ -222,7 +227,7 @@
     "@babel/template" "^7.29.7"
     "@babel/types" "^7.29.7"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.25.3", "@babel/parser@^7.29.0", "@babel/parser@^7.29.7":
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.20.7", "@babel/parser@^7.23.9", "@babel/parser@^7.25.3", "@babel/parser@^7.29.0", "@babel/parser@^7.29.7":
   version "7.29.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.7.tgz#837b87387cbf5ec5530cb634b3c622f68edb9334"
   integrity sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==
@@ -384,6 +389,13 @@
   integrity sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-syntax-typescript@^7.27.1":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz#7c29388932313ed58413a0343048d75d92fb5b24"
+  integrity sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.29.7"
 
 "@babel/plugin-syntax-typescript@^7.28.6":
   version "7.28.6"
@@ -812,6 +824,11 @@
     "@babel/helper-string-parser" "^7.29.7"
     "@babel/helper-validator-identifier" "^7.29.7"
 
+"@bcoe/v8-coverage@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
+  integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
 "@egjs/hammerjs@^2.0.17":
   version "2.0.17"
   resolved "https://registry.yarnpkg.com/@egjs/hammerjs/-/hammerjs-2.0.17.tgz#5dc02af75a6a06e4c2db0202cae38c9263895124"
@@ -819,7 +836,7 @@
   dependencies:
     "@types/hammerjs" "^2.0.36"
 
-"@emnapi/core@^1.4.3":
+"@emnapi/core@1.10.0", "@emnapi/core@^1.4.3":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.10.0.tgz#380ccc8f2412ea22d1d972df7f8ee23a3b9c7467"
   integrity sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==
@@ -827,7 +844,7 @@
     "@emnapi/wasi-threads" "1.2.1"
     tslib "^2.4.0"
 
-"@emnapi/runtime@^1.4.3":
+"@emnapi/runtime@1.10.0", "@emnapi/runtime@^1.4.3":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.10.0.tgz#4b260c0d3534204e98c6110b8db1a987d26ec87c"
   integrity sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==
@@ -1280,6 +1297,18 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
 "@isaacs/ttlcache@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz#21fb23db34e9b6220c6ba023a0118a2dd3461ea2"
@@ -1296,10 +1325,56 @@
     js-yaml "^3.13.1"
     resolve-from "^5.0.0"
 
-"@istanbuljs/schema@^0.1.2":
+"@istanbuljs/schema@^0.1.2", "@istanbuljs/schema@^0.1.3":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.6.tgz#8dc9afa2ac1506cb1a58f89940f1c124446c8df3"
   integrity sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==
+
+"@jest/console@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-30.4.1.tgz#e57725678c3fcc9f7e5597e691e454fee4ce0939"
+  integrity sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==
+  dependencies:
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    jest-message-util "30.4.1"
+    jest-util "30.4.1"
+    slash "^3.0.0"
+
+"@jest/core@30.4.2":
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-30.4.2.tgz#3d4081f894b7e2ff57d04a31842416bd07b76c32"
+  integrity sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==
+  dependencies:
+    "@jest/console" "30.4.1"
+    "@jest/pattern" "30.4.0"
+    "@jest/reporters" "30.4.1"
+    "@jest/test-result" "30.4.1"
+    "@jest/transform" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+    ci-info "^4.2.0"
+    exit-x "^0.2.2"
+    fast-json-stable-stringify "^2.1.0"
+    graceful-fs "^4.2.11"
+    jest-changed-files "30.4.1"
+    jest-config "30.4.2"
+    jest-haste-map "30.4.1"
+    jest-message-util "30.4.1"
+    jest-regex-util "30.4.0"
+    jest-resolve "30.4.1"
+    jest-resolve-dependencies "30.4.2"
+    jest-runner "30.4.2"
+    jest-runtime "30.4.2"
+    jest-snapshot "30.4.1"
+    jest-util "30.4.1"
+    jest-validate "30.4.1"
+    jest-watcher "30.4.1"
+    pretty-format "30.4.1"
+    slash "^3.0.0"
 
 "@jest/create-cache-key-function@^29.7.0":
   version "29.7.0"
@@ -1307,6 +1382,21 @@
   integrity sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==
   dependencies:
     "@jest/types" "^29.6.3"
+
+"@jest/diff-sequences@30.4.0":
+  version "30.4.0"
+  resolved "https://registry.yarnpkg.com/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz#8be2d260e6241d6cddddd102c304fe13b4fc8e3e"
+  integrity sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==
+
+"@jest/environment@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-30.4.1.tgz#1ab5b736e3ce6336d59e00765fa24019649f1a30"
+  integrity sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==
+  dependencies:
+    "@jest/fake-timers" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    jest-mock "30.4.1"
 
 "@jest/environment@^29.7.0":
   version "29.7.0"
@@ -1317,6 +1407,33 @@
     "@jest/types" "^29.6.3"
     "@types/node" "*"
     jest-mock "^29.7.0"
+
+"@jest/expect-utils@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-30.4.1.tgz#e0c7436d52b08610de9027841912dc3734ae80b2"
+  integrity sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+
+"@jest/expect@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-30.4.1.tgz#7fefc67f86c2cb2af3c86d9d41fe4a1d74862b8c"
+  integrity sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==
+  dependencies:
+    expect "30.4.1"
+    jest-snapshot "30.4.1"
+
+"@jest/fake-timers@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-30.4.1.tgz#ad2d3412d5d005a3e45740bd4c8ee1ccae2f89e1"
+  integrity sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==
+  dependencies:
+    "@jest/types" "30.4.1"
+    "@sinonjs/fake-timers" "^15.4.0"
+    "@types/node" "*"
+    jest-message-util "30.4.1"
+    jest-mock "30.4.1"
+    jest-util "30.4.1"
 
 "@jest/fake-timers@^29.7.0":
   version "29.7.0"
@@ -1330,12 +1447,130 @@
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
+"@jest/get-type@30.1.0":
+  version "30.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/get-type/-/get-type-30.1.0.tgz#4fcb4dc2ebcf0811be1c04fd1cb79c2dba431cbc"
+  integrity sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==
+
+"@jest/globals@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-30.4.1.tgz#6376975e137ef87926349b5e75ccf230f491e843"
+  integrity sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==
+  dependencies:
+    "@jest/environment" "30.4.1"
+    "@jest/expect" "30.4.1"
+    "@jest/types" "30.4.1"
+    jest-mock "30.4.1"
+
+"@jest/pattern@30.4.0":
+  version "30.4.0"
+  resolved "https://registry.yarnpkg.com/@jest/pattern/-/pattern-30.4.0.tgz#fcb519eeacc25caa3768f787595a27afa15302ae"
+  integrity sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==
+  dependencies:
+    "@types/node" "*"
+    jest-regex-util "30.4.0"
+
+"@jest/reporters@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-30.4.1.tgz#41d42533f199e737ae352a0a0b32ff300826efe2"
+  integrity sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==
+  dependencies:
+    "@bcoe/v8-coverage" "^0.2.3"
+    "@jest/console" "30.4.1"
+    "@jest/test-result" "30.4.1"
+    "@jest/transform" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    collect-v8-coverage "^1.0.2"
+    exit-x "^0.2.2"
+    glob "^10.5.0"
+    graceful-fs "^4.2.11"
+    istanbul-lib-coverage "^3.0.0"
+    istanbul-lib-instrument "^6.0.0"
+    istanbul-lib-report "^3.0.0"
+    istanbul-lib-source-maps "^5.0.0"
+    istanbul-reports "^3.1.3"
+    jest-message-util "30.4.1"
+    jest-util "30.4.1"
+    jest-worker "30.4.1"
+    slash "^3.0.0"
+    string-length "^4.0.2"
+    v8-to-istanbul "^9.0.1"
+
+"@jest/schemas@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-30.4.1.tgz#c3703fdd71357e2c83aa59bd38469e60a11529c6"
+  integrity sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==
+  dependencies:
+    "@sinclair/typebox" "^0.34.0"
+
 "@jest/schemas@^29.6.3":
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
   integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
   dependencies:
     "@sinclair/typebox" "^0.27.8"
+
+"@jest/snapshot-utils@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz#0f829488b9d46b118854a16a56d509a3c6d9e064"
+  integrity sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==
+  dependencies:
+    "@jest/types" "30.4.1"
+    chalk "^4.1.2"
+    graceful-fs "^4.2.11"
+    natural-compare "^1.4.0"
+
+"@jest/source-map@30.0.1":
+  version "30.0.1"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-30.0.1.tgz#305ebec50468f13e658b3d5c26f85107a5620aaa"
+  integrity sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.25"
+    callsites "^3.1.0"
+    graceful-fs "^4.2.11"
+
+"@jest/test-result@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-30.4.1.tgz#e21146ebbb3e1f7f76c3c49805d9f39ae45f8de1"
+  integrity sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==
+  dependencies:
+    "@jest/console" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/istanbul-lib-coverage" "^2.0.6"
+    collect-v8-coverage "^1.0.2"
+
+"@jest/test-sequencer@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz#caf9a5e0924ed3b04957441edf9e8cef6a804391"
+  integrity sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==
+  dependencies:
+    "@jest/test-result" "30.4.1"
+    graceful-fs "^4.2.11"
+    jest-haste-map "30.4.1"
+    slash "^3.0.0"
+
+"@jest/transform@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-30.4.1.tgz#1646cddb800d38d9c4e30fecfd4a6eba0fa8acfa"
+  integrity sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==
+  dependencies:
+    "@babel/core" "^7.27.4"
+    "@jest/types" "30.4.1"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    babel-plugin-istanbul "^7.0.1"
+    chalk "^4.1.2"
+    convert-source-map "^2.0.0"
+    fast-json-stable-stringify "^2.1.0"
+    graceful-fs "^4.2.11"
+    jest-haste-map "30.4.1"
+    jest-regex-util "30.4.0"
+    jest-util "30.4.1"
+    pirates "^4.0.7"
+    slash "^3.0.0"
+    write-file-atomic "^5.0.1"
 
 "@jest/transform@^29.7.0":
   version "29.7.0"
@@ -1357,6 +1592,19 @@
     pirates "^4.0.4"
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
+
+"@jest/types@30.4.1":
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-30.4.1.tgz#f79b647a85cb2ff4a90cc55984b31dae820db1f7"
+  integrity sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==
+  dependencies:
+    "@jest/pattern" "30.4.0"
+    "@jest/schemas" "30.4.1"
+    "@types/istanbul-lib-coverage" "^2.0.6"
+    "@types/istanbul-reports" "^3.0.4"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.33"
+    chalk "^4.1.2"
 
 "@jest/types@^29.6.3":
   version "29.6.3"
@@ -1404,7 +1652,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
+"@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.23", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
   version "0.3.31"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
   integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
@@ -1421,10 +1669,27 @@
     "@emnapi/runtime" "^1.4.3"
     "@tybys/wasm-util" "^0.10.0"
 
+"@napi-rs/wasm-runtime@^1.1.4":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz#ed33806d0f9be98dc76d0c3d4fd872fda701b5d5"
+  integrity sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==
+  dependencies:
+    "@tybys/wasm-util" "^0.10.3"
+
 "@nolyfill/is-core-module@1.0.39":
   version "1.0.39"
   resolved "https://registry.yarnpkg.com/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz#3dc35ba0f1e66b403c00b39344f870298ebb1c8e"
   integrity sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@pkgr/core@^0.3.6":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.3.6.tgz#3569708bd4be4d8870ba32bf1c456dac81600d97"
+  integrity sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==
 
 "@react-native/assets-registry@0.83.2":
   version "0.83.2"
@@ -1680,7 +1945,12 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.10.tgz#beefe675f1853f73676aecc915b2bd2ac98c4fc6"
   integrity sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==
 
-"@sinonjs/commons@^3.0.0":
+"@sinclair/typebox@^0.34.0":
+  version "0.34.52"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.34.52.tgz#62f8a686e4ab28a8944902e2ad2d648312ef11cb"
+  integrity sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==
+
+"@sinonjs/commons@^3.0.0", "@sinonjs/commons@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-3.0.1.tgz#1029357e44ca901a615585f6d27738dbc89084cd"
   integrity sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==
@@ -1694,6 +1964,13 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@sinonjs/fake-timers@^15.4.0":
+  version "15.4.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz#5d40c151a9e66075fe4520bec40bccfe54931962"
+  integrity sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==
+  dependencies:
+    "@sinonjs/commons" "^3.0.1"
+
 "@tybys/wasm-util@^0.10.0":
   version "0.10.2"
   resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.2.tgz#12b3a1b33db1f9cad4ddff1f604ab7dd00bf464e"
@@ -1701,7 +1978,14 @@
   dependencies:
     tslib "^2.4.0"
 
-"@types/babel__core@^7.1.14":
+"@tybys/wasm-util@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.3.tgz#015cba9e9dd47ce14d03d2a8c5d547bfb169665d"
+  integrity sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==
+  dependencies:
+    tslib "^2.4.0"
+
+"@types/babel__core@^7.1.14", "@types/babel__core@^7.20.5":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
   integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==
@@ -1751,7 +2035,7 @@
   resolved "https://registry.yarnpkg.com/@types/hammerjs/-/hammerjs-2.0.46.tgz#381daaca1360ff8a7c8dff63f32e69745b9fb1e1"
   integrity sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==
 
-"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1", "@types/istanbul-lib-coverage@^2.0.6":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
   integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
@@ -1763,12 +2047,20 @@
   dependencies:
     "@types/istanbul-lib-coverage" "*"
 
-"@types/istanbul-reports@^3.0.0":
+"@types/istanbul-reports@^3.0.0", "@types/istanbul-reports@^3.0.4":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz#0f03e3d2f670fbdac586e34b433783070cc16f54"
   integrity sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==
   dependencies:
     "@types/istanbul-lib-report" "*"
+
+"@types/jest@^30.0.0":
+  version "30.0.0"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-30.0.0.tgz#5e85ae568006712e4ad66f25433e9bdac8801f1d"
+  integrity sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==
+  dependencies:
+    expect "^30.0.0"
+    pretty-format "^30.0.0"
 
 "@types/json-schema@^7.0.15":
   version "7.0.15"
@@ -1787,6 +2079,20 @@
   dependencies:
     undici-types "~7.19.0"
 
+"@types/react-test-renderer@^19.1.0":
+  version "19.1.0"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz#1d0af8f2e1b5931e245b8b5b234d1502b854dc10"
+  integrity sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "19.2.17"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.17.tgz#dccac365baa0f1734ec270ff4b51c89465e8dc7f"
+  integrity sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==
+  dependencies:
+    csstype "^3.2.2"
+
 "@types/react@~19.2.14":
   version "19.2.14"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-19.2.14.tgz#39604929b5e3957e3a6fa0001dafb17c7af70bad"
@@ -1794,7 +2100,7 @@
   dependencies:
     csstype "^3.2.2"
 
-"@types/stack-utils@^2.0.0":
+"@types/stack-utils@^2.0.0", "@types/stack-utils@^2.0.3":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
@@ -1804,7 +2110,7 @@
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
   integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
 
-"@types/yargs@^17.0.8":
+"@types/yargs@^17.0.33", "@types/yargs@^17.0.8":
   version "17.0.35"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.35.tgz#07013e46aa4d7d7d50a49e15604c1c5340d4eb24"
   integrity sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==
@@ -1917,75 +2223,165 @@
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz#9f5b04503088e6a354295e8ea8fe3cb99e43af81"
   integrity sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==
 
+"@unrs/resolver-binding-android-arm-eabi@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz#98a9fee62c01f209747a4ab5855f1ced38a6d03a"
+  integrity sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==
+
 "@unrs/resolver-binding-android-arm64@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz#7414885431bd7178b989aedc4d25cccb3865bc9f"
   integrity sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==
+
+"@unrs/resolver-binding-android-arm64@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz#46b7e8a1393f907462324f1576e8883529acf066"
+  integrity sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==
 
 "@unrs/resolver-binding-darwin-arm64@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz#b4a8556f42171fb9c9f7bac8235045e82aa0cbdf"
   integrity sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==
 
+"@unrs/resolver-binding-darwin-arm64@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz#0ea07b00e2583ab004b853d4c02ec5f0745d490c"
+  integrity sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==
+
 "@unrs/resolver-binding-darwin-x64@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz#fd4d81257b13f4d1a083890a6a17c00de571f0dc"
   integrity sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==
+
+"@unrs/resolver-binding-darwin-x64@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz#a2a6901ed58449b91b4438e582f6890cba956049"
+  integrity sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==
 
 "@unrs/resolver-binding-freebsd-x64@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz#d2513084d0f37c407757e22f32bd924a78cfd99b"
   integrity sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==
 
+"@unrs/resolver-binding-freebsd-x64@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz#ebe6fe7f6706b7378ea4a48a024602e9c2f48f89"
+  integrity sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==
+
 "@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz#844d2605d057488d77fab09705f2866b86164e0a"
   integrity sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==
+
+"@unrs/resolver-binding-linux-arm-gnueabihf@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz#e6040fedaa240124419d35b25b69c5fa15ddb499"
+  integrity sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==
 
 "@unrs/resolver-binding-linux-arm-musleabihf@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz#204892995cefb6bd1d017d52d097193bc61ddad3"
   integrity sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==
 
+"@unrs/resolver-binding-linux-arm-musleabihf@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz#d217a8fb59f659c131539326c140e7b62e3e3c6a"
+  integrity sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==
+
 "@unrs/resolver-binding-linux-arm64-gnu@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz#023eb0c3aac46066a10be7a3f362e7b34f3bdf9d"
   integrity sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==
+
+"@unrs/resolver-binding-linux-arm64-gnu@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz#edab13c46a45783a7e01351e113825c04f352e24"
+  integrity sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==
 
 "@unrs/resolver-binding-linux-arm64-musl@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz#9e6f9abb06424e3140a60ac996139786f5d99be0"
   integrity sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==
 
+"@unrs/resolver-binding-linux-arm64-musl@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz#e5e195db1130f7d3b6aa2fd67b3c9fe1ea4859a0"
+  integrity sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==
+
+"@unrs/resolver-binding-linux-loong64-gnu@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz#f01d22e091bae13016f4636698d9dcbbda775c3e"
+  integrity sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==
+
+"@unrs/resolver-binding-linux-loong64-musl@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz#7d23efcb98adf076bfbcecc27b4212c36aa6697d"
+  integrity sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==
+
 "@unrs/resolver-binding-linux-ppc64-gnu@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz#b111417f17c9d1b02efbec8e08398f0c5527bb44"
   integrity sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==
+
+"@unrs/resolver-binding-linux-ppc64-gnu@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz#1f35f1eaa322f33cf2d96dac27f0626a93ffe2f6"
+  integrity sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==
 
 "@unrs/resolver-binding-linux-riscv64-gnu@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz#92ffbf02748af3e99873945c9a8a5ead01d508a9"
   integrity sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==
 
+"@unrs/resolver-binding-linux-riscv64-gnu@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz#674faa696f5ce96f214873946a1e2d6ca96723dd"
+  integrity sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==
+
 "@unrs/resolver-binding-linux-riscv64-musl@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz#0bec6f1258fc390e6b305e9ff44256cb207de165"
   integrity sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==
+
+"@unrs/resolver-binding-linux-riscv64-musl@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz#37835fdd0b472ecdcffccd4288f19018454b138c"
+  integrity sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==
 
 "@unrs/resolver-binding-linux-s390x-gnu@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz#577843a084c5952f5906770633ccfb89dac9bc94"
   integrity sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==
 
+"@unrs/resolver-binding-linux-s390x-gnu@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz#b6edf13db4bb0accdcd1ad482a4eea0301de9224"
+  integrity sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==
+
 "@unrs/resolver-binding-linux-x64-gnu@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz#36fb318eebdd690f6da32ac5e0499a76fa881935"
   integrity sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==
 
+"@unrs/resolver-binding-linux-x64-gnu@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz#daddad00bf65a405202284da1eb1db8eb83b218f"
+  integrity sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==
+
 "@unrs/resolver-binding-linux-x64-musl@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz#bfb9af75f783f98f6a22c4244214efe4df1853d6"
   integrity sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==
+
+"@unrs/resolver-binding-linux-x64-musl@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz#dfdff1e0c2bad25420b41c76a746011c3983b9bb"
+  integrity sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==
+
+"@unrs/resolver-binding-openharmony-arm64@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz#ce07c4f5e7b42f7bfce45e7629b8659063aefefe"
+  integrity sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==
 
 "@unrs/resolver-binding-wasm32-wasi@1.11.1":
   version "1.11.1"
@@ -1994,20 +2390,44 @@
   dependencies:
     "@napi-rs/wasm-runtime" "^0.2.11"
 
+"@unrs/resolver-binding-wasm32-wasi@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz#82514f0506cfaf65f17fe16095f92d450e487183"
+  integrity sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==
+  dependencies:
+    "@emnapi/core" "1.10.0"
+    "@emnapi/runtime" "1.10.0"
+    "@napi-rs/wasm-runtime" "^1.1.4"
+
 "@unrs/resolver-binding-win32-arm64-msvc@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz#ce5735e600e4c2fbb409cd051b3b7da4a399af35"
   integrity sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==
+
+"@unrs/resolver-binding-win32-arm64-msvc@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz#521427dd59a8f4740ddd1dc7c3bc6af1aa1d260d"
+  integrity sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==
 
 "@unrs/resolver-binding-win32-ia32-msvc@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz#72fc57bc7c64ec5c3de0d64ee0d1810317bc60a6"
   integrity sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==
 
+"@unrs/resolver-binding-win32-ia32-msvc@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz#05b63286ff2da37e0ce3083b8390884385efff62"
+  integrity sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==
+
 "@unrs/resolver-binding-win32-x64-msvc@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
+
+"@unrs/resolver-binding-win32-x64-msvc@1.12.2":
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz#72da0da48d72b1e87831b9c0308931d3f4669027"
+  integrity sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==
 
 "@xmldom/xmldom@^0.8.8":
   version "0.8.13"
@@ -2079,7 +2499,7 @@ anser@^1.4.9:
   resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.10.tgz#befa3eddf282684bd03b63dcda3927aef8c2e35b"
   integrity sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==
 
-ansi-escapes@^4.2.1:
+ansi-escapes@^4.2.1, ansi-escapes@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
   integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
@@ -2096,6 +2516,11 @@ ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-regex@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
+  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -2110,12 +2535,17 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^5.0.0:
+ansi-styles@^5.0.0, ansi-styles@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-anymatch@^3.0.3:
+ansi-styles@^6.1.0:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
+
+anymatch@^3.0.3, anymatch@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
   integrity sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==
@@ -2263,6 +2693,19 @@ axios@^1.18.1:
     https-proxy-agent "^5.0.1"
     proxy-from-env "^2.1.0"
 
+babel-jest@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-30.4.1.tgz#63cba904438bbe64c4cf0acdea87b0a45cb809fc"
+  integrity sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==
+  dependencies:
+    "@jest/transform" "30.4.1"
+    "@types/babel__core" "^7.20.5"
+    babel-plugin-istanbul "^7.0.1"
+    babel-preset-jest "30.4.0"
+    chalk "^4.1.2"
+    graceful-fs "^4.2.11"
+    slash "^3.0.0"
+
 babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
@@ -2286,6 +2729,24 @@ babel-plugin-istanbul@^6.1.1:
     "@istanbuljs/schema" "^0.1.2"
     istanbul-lib-instrument "^5.0.4"
     test-exclude "^6.0.0"
+
+babel-plugin-istanbul@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz#d8b518c8ea199364cf84ccc82de89740236daf92"
+  integrity sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@istanbuljs/load-nyc-config" "^1.0.0"
+    "@istanbuljs/schema" "^0.1.3"
+    istanbul-lib-instrument "^6.0.2"
+    test-exclude "^6.0.0"
+
+babel-plugin-jest-hoist@30.4.0:
+  version "30.4.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz#f7d6a6d8f435808b56b45a81dc4b61a39e36794a"
+  integrity sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==
+  dependencies:
+    "@types/babel__core" "^7.20.5"
 
 babel-plugin-jest-hoist@^29.6.3:
   version "29.6.3"
@@ -2354,7 +2815,7 @@ babel-plugin-transform-flow-enums@^0.0.2:
   dependencies:
     "@babel/plugin-syntax-flow" "^7.12.1"
 
-babel-preset-current-node-syntax@^1.0.0:
+babel-preset-current-node-syntax@^1.0.0, babel-preset-current-node-syntax@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz#20730d6cdc7dda5d89401cab10ac6a32067acde6"
   integrity sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==
@@ -2403,6 +2864,14 @@ babel-preset-expo@~55.0.19:
     babel-plugin-transform-flow-enums "^0.0.2"
     debug "^4.3.4"
     resolve-from "^5.0.0"
+
+babel-preset-jest@30.4.0:
+  version "30.4.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz#295486c2ec1127b3dc7d0d2adaa72a1dcaaafccd"
+  integrity sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==
+  dependencies:
+    babel-plugin-jest-hoist "30.4.0"
+    babel-preset-current-node-syntax "^1.2.0"
 
 babel-preset-jest@^29.6.3:
   version "29.6.3"
@@ -2478,6 +2947,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
+  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 brace-expansion@^5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
@@ -2502,6 +2978,13 @@ browserslist@^4.24.0, browserslist@^4.25.0, browserslist@^4.28.1:
     electron-to-chromium "^1.5.328"
     node-releases "^2.0.36"
     update-browserslist-db "^1.2.3"
+
+bs-logger@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
+  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
+  dependencies:
+    fast-json-stable-stringify "2.x"
 
 bser@2.1.1:
   version "2.1.1"
@@ -2546,7 +3029,7 @@ call-bound@^1.0.2, call-bound@^1.0.3, call-bound@^1.0.4:
     call-bind-apply-helpers "^1.0.2"
     get-intrinsic "^1.3.0"
 
-callsites@^3.0.0:
+callsites@^3.0.0, callsites@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
@@ -2556,7 +3039,7 @@ camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.2.0:
+camelcase@^6.2.0, camelcase@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
@@ -2582,6 +3065,11 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+char-regex@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
+  integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
 chrome-launcher@^0.15.2:
   version "0.15.2"
@@ -2615,6 +3103,16 @@ ci-info@^3.2.0, ci-info@^3.3.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
+ci-info@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.4.0.tgz#7d54eff9f54b45b62401c26032696eb59c8bd18c"
+  integrity sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==
+
+cjs-module-lexer@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz#b3ca5101843389259ade7d88c77bd06ce55849ca"
+  integrity sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -2640,6 +3138,16 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
+
+co@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+  integrity sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==
+
+collect-v8-coverage@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz#cc1f01eb8d02298cbc9a437c74c70ab4e5210b80"
+  integrity sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -2822,7 +3330,7 @@ debug@2.6.9, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0, debug@^4.4.3:
+debug@4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.5, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -2840,6 +3348,11 @@ decode-uri-component@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
+
+dedent@^1.6.0:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.7.2.tgz#34e2264ab538301e27cf7b07bf2369c19baa8dd9"
+  integrity sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -2901,6 +3414,11 @@ detect-libc@^2.0.3:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
+detect-newline@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
 dnssd-advertise@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/dnssd-advertise/-/dnssd-advertise-1.1.4.tgz#0744865a4fa2569a44dcb9aff267022aaf2803b2"
@@ -2952,6 +3470,11 @@ dunder-proto@^1.0.0, dunder-proto@^1.0.1:
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -2962,10 +3485,20 @@ electron-to-chromium@^1.5.328:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz#9b9c6a6d84d1107557c18a9336099ce0ee890e5b"
   integrity sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==
 
+emittery@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
+  integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -2981,6 +3514,13 @@ entities@^4.2.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+error-ex@^1.3.1:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.4.tgz#b3a8d8bb6f92eecc1629e3e27d3c8607a8a32414"
+  integrity sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==
+  dependencies:
+    is-arrayish "^0.2.1"
 
 error-stack-parser@^2.0.6:
   version "2.1.4"
@@ -3356,6 +3896,38 @@ event-target-shim@^5.0.0:
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
+execa@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
+  integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
+    strip-final-newline "^2.0.0"
+
+exit-x@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/exit-x/-/exit-x-0.2.2.tgz#1f9052de3b8d99a696b10dad5bced9bdd5c3aa64"
+  integrity sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==
+
+expect@30.4.1, expect@^30.0.0:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-30.4.1.tgz#897e0390a0b6c333dbcf3a24dee3ad49553577e0"
+  integrity sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==
+  dependencies:
+    "@jest/expect-utils" "30.4.1"
+    "@jest/get-type" "30.1.0"
+    jest-matcher-utils "30.4.1"
+    jest-message-util "30.4.1"
+    jest-mock "30.4.1"
+    jest-util "30.4.1"
+
 expo-asset@~55.0.16:
   version "55.0.16"
   resolved "https://registry.yarnpkg.com/expo-asset/-/expo-asset-55.0.16.tgz#e7c8d7140e4d8958d3b8fa3d9ea6642cb49369b2"
@@ -3418,6 +3990,11 @@ expo-screen-orientation@~55.0.9:
   resolved "https://registry.yarnpkg.com/expo-screen-orientation/-/expo-screen-orientation-55.0.13.tgz#b460a852578b39502f72516eb95b7e944aaef29f"
   integrity sha512-nIqZdaUGBQpmJP5A5Te1AxIR5chKLICj5he6EjOzqae00WC4JPadlC+thWCngvmAW6cvINUahd9+leOhLQ2q4w==
 
+expo-secure-store@^57.0.1:
+  version "57.0.1"
+  resolved "https://registry.yarnpkg.com/expo-secure-store/-/expo-secure-store-57.0.1.tgz#746892729ca7a78513a1c220b48c1f3f803af413"
+  integrity sha512-tLa1VmSadOq19mA/dwkl99RbHyjLE0T1qqBYMY3/OsguZTI+rlrDy/DDJjupqlVtmr95hD7o1pYqx5aL+B4YMA==
+
 expo-server@^55.0.8:
   version "55.0.8"
   resolved "https://registry.yarnpkg.com/expo-server/-/expo-server-55.0.8.tgz#a1fbaa70a094bb4a1132f944b30ccd6e1a8cedd3"
@@ -3469,7 +4046,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -3484,7 +4061,7 @@ fb-dotslash@0.5.8:
   resolved "https://registry.yarnpkg.com/fb-dotslash/-/fb-dotslash-0.5.8.tgz#c5ef3dacd75e1ddb2197c367052464ddde0115f5"
   integrity sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==
 
-fb-watchman@^2.0.0:
+fb-watchman@^2.0.0, fb-watchman@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.2.tgz#e9524ee6b5c77e9e5001af0f85f3adbb8623255c"
   integrity sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==
@@ -3533,7 +4110,7 @@ finalhandler@1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-up@^4.1.0:
+find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -3584,6 +4161,14 @@ for-each@^0.3.3, for-each@^0.3.5:
   dependencies:
     is-callable "^1.2.7"
 
+foreground-child@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
+
 form-data@^4.0.5:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
@@ -3605,7 +4190,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2:
+fsevents@^2.3.2, fsevents@^2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -3676,6 +4261,11 @@ get-proto@^1.0.0, get-proto@^1.0.1:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
 
+get-stream@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
 get-symbol-description@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/get-symbol-description/-/get-symbol-description-1.1.0.tgz#7bdd54e0befe8ffc9f3b4e203220d9f1e881b6ee"
@@ -3703,6 +4293,18 @@ glob-parent@^6.0.2:
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
   dependencies:
     is-glob "^4.0.3"
+
+glob@^10.5.0:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
 
 glob@^13.0.0:
   version "13.0.6"
@@ -3748,10 +4350,22 @@ gopd@^1.0.1, gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-graceful-fs@^4.2.4, graceful-fs@^4.2.9:
+graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+handlebars@^4.7.9:
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.2"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
 
 has-bigints@^1.0.2:
   version "1.1.0"
@@ -3863,6 +4477,11 @@ hosted-git-info@^7.0.0:
   dependencies:
     lru-cache "^10.0.1"
 
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+
 http-errors@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.1.tgz#36d2f65bc909c8790018dd36fb4d93da6caae06b"
@@ -3890,6 +4509,11 @@ https-proxy-agent@^7.0.5:
     agent-base "^7.1.2"
     debug "4"
 
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
 ignore@^5.2.0, ignore@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
@@ -3914,6 +4538,14 @@ import-fresh@^3.2.1:
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
+
+import-local@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.2.0.tgz#c3d5c745798c02a6f8b897726aba5100186ee260"
+  integrity sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==
+  dependencies:
+    pkg-dir "^4.2.0"
+    resolve-cwd "^3.0.0"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -3957,6 +4589,11 @@ is-array-buffer@^3.0.4, is-array-buffer@^3.0.5:
     call-bind "^1.0.8"
     call-bound "^1.0.3"
     get-intrinsic "^1.2.6"
+
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+  integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
 is-arrayish@^0.3.1:
   version "0.3.4"
@@ -4047,6 +4684,11 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
+is-generator-fn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
+  integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
+
 is-generator-function@^1.0.10:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.1.2.tgz#ae3b61e3d5ea4e4839b90bad22b02335051a17d5"
@@ -4110,6 +4752,11 @@ is-shared-array-buffer@^1.0.4:
   dependencies:
     call-bound "^1.0.3"
 
+is-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
 is-string@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.1.1.tgz#92ea3f3d5c5b6e039ca8677e5ac8d07ea773cbb9"
@@ -4171,7 +4818,7 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-istanbul-lib-coverage@^3.2.0:
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz#2d166c4b0644d43a39f04bf6c2edd1e585f31756"
   integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
@@ -4187,6 +4834,43 @@ istanbul-lib-instrument@^5.0.4:
     istanbul-lib-coverage "^3.2.0"
     semver "^6.3.0"
 
+istanbul-lib-instrument@^6.0.0, istanbul-lib-instrument@^6.0.2:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz#fa15401df6c15874bcb2105f773325d78c666765"
+  integrity sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==
+  dependencies:
+    "@babel/core" "^7.23.9"
+    "@babel/parser" "^7.23.9"
+    "@istanbuljs/schema" "^0.1.3"
+    istanbul-lib-coverage "^3.2.0"
+    semver "^7.5.4"
+
+istanbul-lib-report@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz#908305bac9a5bd175ac6a74489eafd0fc2445a7d"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
+
+istanbul-lib-source-maps@^5.0.0:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz#acaef948df7747c8eb5fbf1265cb980f6353a441"
+  integrity sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.23"
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+
+istanbul-reports@^3.1.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-3.2.0.tgz#cb4535162b5784aa623cee21a7252cf2c807ac93"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
+
 iterator.prototype@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/iterator.prototype/-/iterator.prototype-1.1.5.tgz#12c959a29de32de0aa3bbbb801f4d777066dae39"
@@ -4198,6 +4882,136 @@ iterator.prototype@^1.1.5:
     get-proto "^1.0.0"
     has-symbols "^1.1.0"
     set-function-name "^2.0.2"
+
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
+jest-changed-files@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-30.4.1.tgz#396fcf914165287f05960372a5d091f6f2275ec5"
+  integrity sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==
+  dependencies:
+    execa "^5.1.1"
+    jest-util "30.4.1"
+    p-limit "^3.1.0"
+
+jest-circus@30.4.2:
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-30.4.2.tgz#9a5b9b9c57bf51871f112ccf7a673d486c28f8e7"
+  integrity sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==
+  dependencies:
+    "@jest/environment" "30.4.1"
+    "@jest/expect" "30.4.1"
+    "@jest/test-result" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    co "^4.6.0"
+    dedent "^1.6.0"
+    is-generator-fn "^2.1.0"
+    jest-each "30.4.1"
+    jest-matcher-utils "30.4.1"
+    jest-message-util "30.4.1"
+    jest-runtime "30.4.2"
+    jest-snapshot "30.4.1"
+    jest-util "30.4.1"
+    p-limit "^3.1.0"
+    pretty-format "30.4.1"
+    pure-rand "^7.0.0"
+    slash "^3.0.0"
+    stack-utils "^2.0.6"
+
+jest-cli@30.4.2:
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-30.4.2.tgz#e353ef54035c5ac97f200807c97b3d857f52bddc"
+  integrity sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==
+  dependencies:
+    "@jest/core" "30.4.2"
+    "@jest/test-result" "30.4.1"
+    "@jest/types" "30.4.1"
+    chalk "^4.1.2"
+    exit-x "^0.2.2"
+    import-local "^3.2.0"
+    jest-config "30.4.2"
+    jest-util "30.4.1"
+    jest-validate "30.4.1"
+    yargs "^17.7.2"
+
+jest-config@30.4.2:
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-30.4.2.tgz#78f589b5410d2805518b8bdce517217fb96b5e61"
+  integrity sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==
+  dependencies:
+    "@babel/core" "^7.27.4"
+    "@jest/get-type" "30.1.0"
+    "@jest/pattern" "30.4.0"
+    "@jest/test-sequencer" "30.4.1"
+    "@jest/types" "30.4.1"
+    babel-jest "30.4.1"
+    chalk "^4.1.2"
+    ci-info "^4.2.0"
+    deepmerge "^4.3.1"
+    glob "^10.5.0"
+    graceful-fs "^4.2.11"
+    jest-circus "30.4.2"
+    jest-docblock "30.4.0"
+    jest-environment-node "30.4.1"
+    jest-regex-util "30.4.0"
+    jest-resolve "30.4.1"
+    jest-runner "30.4.2"
+    jest-util "30.4.1"
+    jest-validate "30.4.1"
+    parse-json "^5.2.0"
+    pretty-format "30.4.1"
+    slash "^3.0.0"
+    strip-json-comments "^3.1.1"
+
+jest-diff@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-30.4.1.tgz#26691c73975768409af4a66b2754cea3182aa2dc"
+  integrity sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==
+  dependencies:
+    "@jest/diff-sequences" "30.4.0"
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    pretty-format "30.4.1"
+
+jest-docblock@30.4.0:
+  version "30.4.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-30.4.0.tgz#3ab779a027d1495ae21550accd4266bbe99af7a3"
+  integrity sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==
+  dependencies:
+    detect-newline "^3.1.0"
+
+jest-each@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-30.4.1.tgz#b69e66da8e2b578c6140d357f6574044c2a40537"
+  integrity sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    "@jest/types" "30.4.1"
+    chalk "^4.1.2"
+    jest-util "30.4.1"
+    pretty-format "30.4.1"
+
+jest-environment-node@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-30.4.1.tgz#43bbbee903e17d874eb1817195c50ff8b90e2fe0"
+  integrity sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==
+  dependencies:
+    "@jest/environment" "30.4.1"
+    "@jest/fake-timers" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    jest-mock "30.4.1"
+    jest-util "30.4.1"
+    jest-validate "30.4.1"
 
 jest-environment-node@^29.7.0:
   version "29.7.0"
@@ -4215,6 +5029,24 @@ jest-get-type@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
   integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
+
+jest-haste-map@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-30.4.1.tgz#6d80d09d668c20bf3944977e50acac94fcd672fe"
+  integrity sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==
+  dependencies:
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    anymatch "^3.1.3"
+    fb-watchman "^2.0.2"
+    graceful-fs "^4.2.11"
+    jest-regex-util "30.4.0"
+    jest-util "30.4.1"
+    jest-worker "30.4.1"
+    picomatch "^4.0.3"
+    walker "^1.0.8"
+  optionalDependencies:
+    fsevents "^2.3.3"
 
 jest-haste-map@^29.7.0:
   version "29.7.0"
@@ -4235,6 +5067,40 @@ jest-haste-map@^29.7.0:
   optionalDependencies:
     fsevents "^2.3.2"
 
+jest-leak-detector@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz#96077059a68e5871fc8f53aa90647a6a33f916cd"
+  integrity sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    pretty-format "30.4.1"
+
+jest-matcher-utils@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz#3fee8c89dbd8fc6e60eb590def9897e18f110ec4"
+  integrity sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    chalk "^4.1.2"
+    jest-diff "30.4.1"
+    pretty-format "30.4.1"
+
+jest-message-util@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-30.4.1.tgz#40f6bfa5f564363edcba7ce0ca64277fd2ad6af7"
+  integrity sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==
+  dependencies:
+    "@babel/code-frame" "^7.27.1"
+    "@jest/types" "30.4.1"
+    "@types/stack-utils" "^2.0.3"
+    chalk "^4.1.2"
+    graceful-fs "^4.2.11"
+    jest-util "30.4.1"
+    picomatch "^4.0.3"
+    pretty-format "30.4.1"
+    slash "^3.0.0"
+    stack-utils "^2.0.6"
+
 jest-message-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.7.0.tgz#8bc392e204e95dfe7564abbe72a404e28e51f7f3"
@@ -4250,6 +5116,15 @@ jest-message-util@^29.7.0:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
+jest-mock@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-30.4.1.tgz#5e11a05d7719a1e3c7bba6348b70ff4e1bc5ea68"
+  integrity sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==
+  dependencies:
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    jest-util "30.4.1"
+
 jest-mock@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.7.0.tgz#4e836cf60e99c6fcfabe9f99d017f3fdd50a6347"
@@ -4259,10 +5134,137 @@ jest-mock@^29.7.0:
     "@types/node" "*"
     jest-util "^29.7.0"
 
+jest-pnp-resolver@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz#930b1546164d4ad5937d5540e711d4d38d4cad2e"
+  integrity sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==
+
+jest-regex-util@30.4.0:
+  version "30.4.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-30.4.0.tgz#f75ccc43857633df2563a03588b5cb45c7c2941b"
+  integrity sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==
+
 jest-regex-util@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-29.6.3.tgz#4a556d9c776af68e1c5f48194f4d0327d24e8a52"
   integrity sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==
+
+jest-resolve-dependencies@30.4.2:
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz#152f8a4cb2dd351cedeb5ada53c89f9683a3ad92"
+  integrity sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==
+  dependencies:
+    jest-regex-util "30.4.0"
+    jest-snapshot "30.4.1"
+
+jest-resolve@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-30.4.1.tgz#b9e432892dc0e2a470eb4826ef5f120a50b3205e"
+  integrity sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==
+  dependencies:
+    chalk "^4.1.2"
+    graceful-fs "^4.2.11"
+    jest-haste-map "30.4.1"
+    jest-pnp-resolver "^1.2.3"
+    jest-util "30.4.1"
+    jest-validate "30.4.1"
+    slash "^3.0.0"
+    unrs-resolver "^1.7.11"
+
+jest-runner@30.4.2:
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-30.4.2.tgz#15debf3cb6d817538aa97427d5a79277cdff65fe"
+  integrity sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==
+  dependencies:
+    "@jest/console" "30.4.1"
+    "@jest/environment" "30.4.1"
+    "@jest/test-result" "30.4.1"
+    "@jest/transform" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    emittery "^0.13.1"
+    exit-x "^0.2.2"
+    graceful-fs "^4.2.11"
+    jest-docblock "30.4.0"
+    jest-environment-node "30.4.1"
+    jest-haste-map "30.4.1"
+    jest-leak-detector "30.4.1"
+    jest-message-util "30.4.1"
+    jest-resolve "30.4.1"
+    jest-runtime "30.4.2"
+    jest-util "30.4.1"
+    jest-watcher "30.4.1"
+    jest-worker "30.4.1"
+    p-limit "^3.1.0"
+    source-map-support "0.5.13"
+
+jest-runtime@30.4.2:
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-30.4.2.tgz#03b5955003440975b12e76518ec85d091c25b84a"
+  integrity sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==
+  dependencies:
+    "@jest/environment" "30.4.1"
+    "@jest/fake-timers" "30.4.1"
+    "@jest/globals" "30.4.1"
+    "@jest/source-map" "30.0.1"
+    "@jest/test-result" "30.4.1"
+    "@jest/transform" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    cjs-module-lexer "^2.1.0"
+    collect-v8-coverage "^1.0.2"
+    glob "^10.5.0"
+    graceful-fs "^4.2.11"
+    jest-haste-map "30.4.1"
+    jest-message-util "30.4.1"
+    jest-mock "30.4.1"
+    jest-regex-util "30.4.0"
+    jest-resolve "30.4.1"
+    jest-snapshot "30.4.1"
+    jest-util "30.4.1"
+    slash "^3.0.0"
+    strip-bom "^4.0.0"
+
+jest-snapshot@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-30.4.1.tgz#0380cbbaa9d53d32cf7e61af98459ac10a339842"
+  integrity sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==
+  dependencies:
+    "@babel/core" "^7.27.4"
+    "@babel/generator" "^7.27.5"
+    "@babel/plugin-syntax-jsx" "^7.27.1"
+    "@babel/plugin-syntax-typescript" "^7.27.1"
+    "@babel/types" "^7.27.3"
+    "@jest/expect-utils" "30.4.1"
+    "@jest/get-type" "30.1.0"
+    "@jest/snapshot-utils" "30.4.1"
+    "@jest/transform" "30.4.1"
+    "@jest/types" "30.4.1"
+    babel-preset-current-node-syntax "^1.2.0"
+    chalk "^4.1.2"
+    expect "30.4.1"
+    graceful-fs "^4.2.11"
+    jest-diff "30.4.1"
+    jest-matcher-utils "30.4.1"
+    jest-message-util "30.4.1"
+    jest-util "30.4.1"
+    pretty-format "30.4.1"
+    semver "^7.7.2"
+    synckit "^0.11.8"
+
+jest-util@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-30.4.1.tgz#979c9d014fdd12bb95d3dcde0192e1a9e0bc93d6"
+  integrity sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==
+  dependencies:
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    chalk "^4.1.2"
+    ci-info "^4.2.0"
+    graceful-fs "^4.2.11"
+    picomatch "^4.0.3"
 
 jest-util@^29.7.0:
   version "29.7.0"
@@ -4276,6 +5278,18 @@ jest-util@^29.7.0:
     graceful-fs "^4.2.9"
     picomatch "^2.2.3"
 
+jest-validate@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-30.4.1.tgz#dcc4784547bf644dca0226d3266fb1bde392c5a4"
+  integrity sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==
+  dependencies:
+    "@jest/get-type" "30.1.0"
+    "@jest/types" "30.4.1"
+    camelcase "^6.3.0"
+    chalk "^4.1.2"
+    leven "^3.1.0"
+    pretty-format "30.4.1"
+
 jest-validate@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-29.7.0.tgz#7bf705511c64da591d46b15fce41400d52147d9c"
@@ -4288,6 +5302,31 @@ jest-validate@^29.7.0:
     leven "^3.1.0"
     pretty-format "^29.7.0"
 
+jest-watcher@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-30.4.1.tgz#d2a78fd27553db9206947eeda6068d76bacfd276"
+  integrity sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==
+  dependencies:
+    "@jest/test-result" "30.4.1"
+    "@jest/types" "30.4.1"
+    "@types/node" "*"
+    ansi-escapes "^4.3.2"
+    chalk "^4.1.2"
+    emittery "^0.13.1"
+    jest-util "30.4.1"
+    string-length "^4.0.2"
+
+jest-worker@30.4.1:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-30.4.1.tgz#ac010eb6c512425748a39e2d6bf05b2c4866ca4f"
+  integrity sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==
+  dependencies:
+    "@types/node" "*"
+    "@ungap/structured-clone" "^1.3.0"
+    jest-util "30.4.1"
+    merge-stream "^2.0.0"
+    supports-color "^8.1.1"
+
 jest-worker@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.7.0.tgz#acad073acbbaeb7262bd5389e1bcf43e10058d4a"
@@ -4297,6 +5336,16 @@ jest-worker@^29.7.0:
     jest-util "^29.7.0"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
+
+jest@^30.4.2:
+  version "30.4.2"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-30.4.2.tgz#e9bdb00f4bf1126d781b0d98e23130db096bbd9a"
+  integrity sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==
+  dependencies:
+    "@jest/core" "30.4.2"
+    "@jest/types" "30.4.1"
+    import-local "^3.2.0"
+    jest-cli "30.4.2"
 
 jimp-compact@0.16.1:
   version "0.16.1"
@@ -4337,6 +5386,11 @@ json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
+json-parse-even-better-errors@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
+  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -4482,6 +5536,11 @@ lightningcss@^1.30.1:
     lightningcss-win32-arm64-msvc "1.32.0"
     lightningcss-win32-x64-msvc "1.32.0"
 
+lines-and-columns@^1.1.6:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
+  integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -4500,6 +5559,11 @@ lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
+
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
 
 lodash.merge@^4.6.2:
   version "4.6.2"
@@ -4525,7 +5589,7 @@ loose-envify@^1.0.0, loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lru-cache@^10.0.1:
+lru-cache@^10.0.1, lru-cache@^10.2.0:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
@@ -4541,6 +5605,18 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
+
+make-error@^1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 makeerror@1.0.12:
   version "1.0.12"
@@ -4808,6 +5884,11 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
+mimic-fn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
 minimatch@^10.2.2:
   version "10.2.5"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.5.tgz#bd48687a0be38ed2961399105600f832095861d1"
@@ -4822,12 +5903,19 @@ minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2, minimatch@^3.1.5:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.6:
+minimatch@^9.0.4:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
+
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
-minipass@^7.1.2, minipass@^7.1.3:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2, minipass@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
   integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
@@ -4857,7 +5945,7 @@ nanoid@^3.3.11:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
   integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
 
-napi-postinstall@^0.3.0:
+napi-postinstall@^0.3.0, napi-postinstall@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/napi-postinstall/-/napi-postinstall-0.3.4.tgz#7af256d6588b5f8e952b9190965d6b019653bbb9"
   integrity sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==
@@ -4881,6 +5969,11 @@ negotiator@~0.6.4:
   version "0.6.4"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.4.tgz#777948e2452651c570b712dd01c23e262713fff7"
   integrity sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==
+
+neo-async@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
 node-exports-info@^1.6.0:
   version "1.6.0"
@@ -4921,6 +6014,13 @@ npm-package-arg@^11.0.0:
     proc-log "^4.0.0"
     semver "^7.3.5"
     validate-npm-package-name "^5.0.0"
+
+npm-run-path@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
+  dependencies:
+    path-key "^3.0.0"
 
 nth-check@^2.0.1:
   version "2.1.1"
@@ -5040,6 +6140,13 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+onetime@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
+  dependencies:
+    mimic-fn "^2.1.0"
+
 open@^7.0.3:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
@@ -5097,7 +6204,7 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -5123,12 +6230,27 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse-json@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
+  integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-even-better-errors "^2.3.0"
+    lines-and-columns "^1.1.6"
 
 parse-png@^2.1.0:
   version "2.1.0"
@@ -5152,7 +6274,7 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
-path-key@^3.1.0:
+path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
@@ -5161,6 +6283,14 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 path-scurry@^2.0.2:
   version "2.0.2"
@@ -5185,10 +6315,17 @@ picomatch@^4.0.3, picomatch@^4.0.4:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
-pirates@^4.0.4:
+pirates@^4.0.4, pirates@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
   integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
+
+pkg-dir@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
+  integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+  dependencies:
+    find-up "^4.0.0"
 
 plist@^3.0.5:
   version "3.1.1"
@@ -5222,6 +6359,16 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+pretty-format@30.4.1, pretty-format@^30.0.0:
+  version "30.4.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-30.4.1.tgz#0911652e92e1e91f475e3e6a16e628e50649ea69"
+  integrity sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==
+  dependencies:
+    "@jest/schemas" "30.4.1"
+    ansi-styles "^5.2.0"
+    react-is-18 "npm:react-is@^18.3.1"
+    react-is-19 "npm:react-is@^19.2.5"
 
 pretty-format@^29.7.0:
   version "29.7.0"
@@ -5276,6 +6423,11 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
+pure-rand@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/pure-rand/-/pure-rand-7.0.1.tgz#6f53a5a9e3e4a47445822af96821ca509ed37566"
+  integrity sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==
+
 query-string@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.3.tgz#a1cf90e994abb113a325804a972d98276fe02328"
@@ -5305,6 +6457,21 @@ react-devtools-core@^6.1.5:
   dependencies:
     shell-quote "^1.6.1"
     ws "^7"
+
+react-freeze@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/react-freeze/-/react-freeze-1.0.4.tgz#cbbea2762b0368b05cbe407ddc9d518c57c6f3ad"
+  integrity sha512-r4F0Sec0BLxWicc7HEyo2x3/2icUTrRmDjaaRyzzn+7aDyFZliszMDOgLVwSnQnYENOlL1o569Ze2HZefk8clA==
+
+"react-is-18@npm:react-is@^18.3.1":
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
+
+"react-is-19@npm:react-is@^19.2.5":
+  version "19.2.7"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.7.tgz#57668ee86a78574a542b0a539455212b2c086df2"
+  integrity sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
@@ -5347,6 +6514,19 @@ react-native-reanimated@4.2.2:
   dependencies:
     react-native-is-edge-to-edge "1.2.1"
     semver "7.7.3"
+
+react-native-safe-area-context@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-5.8.0.tgz#d2fb9fc8e0f0583311e261dc484b95ceb80f8902"
+  integrity sha512-t+ZsAVzY/wWzzx34vqGbo3/as9EEESJdbyZNL7Yg5EYX+toYMtMqFoDDCvqZUi35eeGVsXc6pAaEk4edMwbuCQ==
+
+react-native-screens@^4.26.2:
+  version "4.26.2"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-4.26.2.tgz#cfc007736526a0958e8e8d3ff5f77202c323a852"
+  integrity sha512-2XnWsZToKj76trGtEZzx5ELD/qOICFEprEeUntImmitQFVUkea27fiWdUSITArI356Y1qynpXZINW+Unbhky/A==
+  dependencies:
+    react-freeze "^1.0.0"
+    warn-once "^0.1.0"
 
 react-native-share@^12.2.0:
   version "12.3.1"
@@ -5502,6 +6682,13 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
+resolve-cwd@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
+  integrity sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
+  dependencies:
+    resolve-from "^5.0.0"
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -5616,6 +6803,11 @@ semver@^7.1.3, semver@^7.3.5, semver@^7.5.4, semver@^7.6.0, semver@^7.7.1, semve
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.4.tgz#28464e36060e991fa7a11d0279d2d3f3b57a7e8a"
   integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
+
+semver@^7.5.3, semver@^7.7.2, semver@^7.8.0:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 send@^0.19.0, send@~0.19.1:
   version "0.19.2"
@@ -5744,10 +6936,15 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
-signal-exit@^3.0.2, signal-exit@^3.0.7:
+signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 simple-plist@^1.1.0:
   version "1.3.1"
@@ -5785,6 +6982,14 @@ source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+source-map-support@0.5.13:
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
+  integrity sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@~0.5.20, source-map-support@~0.5.21:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
@@ -5818,7 +7023,7 @@ stable-hash@^0.0.5:
   resolved "https://registry.yarnpkg.com/stable-hash/-/stable-hash-0.0.5.tgz#94e8837aaeac5b4d0f631d2972adef2924b40269"
   integrity sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==
 
-stack-utils@^2.0.3:
+stack-utils@^2.0.3, stack-utils@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.6.tgz#aaf0748169c02fc33c8232abccf933f54a1cc34f"
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
@@ -5870,6 +7075,23 @@ strict-uri-encode@^2.0.0:
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
   integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
+string-length@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-4.0.2.tgz#a8a8dc7bd5c1a82b9b3c8b87e125f66871b6e57a"
+  integrity sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==
+  dependencies:
+    char-regex "^1.0.2"
+    strip-ansi "^6.0.0"
+
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -5878,6 +7100,15 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
 
 string.prototype.matchall@^4.0.12:
   version "4.0.12"
@@ -5938,6 +7169,13 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
 strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
@@ -5952,10 +7190,27 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
+strip-ansi@^7.0.1:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
+
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==
+
+strip-bom@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
+  integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
+
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-json-comments@^3.1.1:
   version "3.1.1"
@@ -5981,7 +7236,7 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.0.0:
+supports-color@^8.0.0, supports-color@^8.1.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -6000,6 +7255,13 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+synckit@^0.11.8:
+  version "0.11.13"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.11.13.tgz#062a5ea57d81befc35892f8254de5c567e97c80a"
+  integrity sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==
+  dependencies:
+    "@pkgr/core" "^0.3.6"
 
 terminal-link@^2.1.1:
   version "2.1.1"
@@ -6068,6 +7330,21 @@ ts-api-utils@^2.5.0:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.5.0.tgz#4acd4a155e22734990a5ed1fe9e97f113bcb37c1"
   integrity sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==
 
+ts-jest@^29.4.11:
+  version "29.4.11"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.4.11.tgz#42f5de21c37ccc01a580253afae6955abbf4d0b3"
+  integrity sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==
+  dependencies:
+    bs-logger "^0.2.6"
+    fast-json-stable-stringify "^2.1.0"
+    handlebars "^4.7.9"
+    json5 "^2.2.3"
+    lodash.memoize "^4.1.2"
+    make-error "^1.3.6"
+    semver "^7.8.0"
+    type-fest "^4.41.0"
+    yargs-parser "^21.1.1"
+
 tsconfig-paths@^3.15.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz#5299ec605e55b1abb23ec939ef15edaf483070d4"
@@ -6104,6 +7381,11 @@ type-fest@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.7.1.tgz#8dda65feaf03ed78f0a3f9678f1869147f7c5c48"
   integrity sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==
+
+type-fest@^4.41.0:
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
 
 typed-array-buffer@^1.0.3:
   version "1.0.3"
@@ -6154,6 +7436,11 @@ typescript@~5.9.3:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+uglify-js@^3.1.4:
+  version "3.19.3"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.19.3.tgz#82315e9bbc6f2b25888858acd1fff8441035b77f"
+  integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
 
 unbox-primitive@^1.1.0:
   version "1.1.0"
@@ -6225,6 +7512,36 @@ unrs-resolver@^1.6.2:
     "@unrs/resolver-binding-win32-ia32-msvc" "1.11.1"
     "@unrs/resolver-binding-win32-x64-msvc" "1.11.1"
 
+unrs-resolver@^1.7.11:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/unrs-resolver/-/unrs-resolver-1.12.2.tgz#a6c6888396abba5adaac4cab6587df866f1d7afd"
+  integrity sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==
+  dependencies:
+    napi-postinstall "^0.3.4"
+  optionalDependencies:
+    "@unrs/resolver-binding-android-arm-eabi" "1.12.2"
+    "@unrs/resolver-binding-android-arm64" "1.12.2"
+    "@unrs/resolver-binding-darwin-arm64" "1.12.2"
+    "@unrs/resolver-binding-darwin-x64" "1.12.2"
+    "@unrs/resolver-binding-freebsd-x64" "1.12.2"
+    "@unrs/resolver-binding-linux-arm-gnueabihf" "1.12.2"
+    "@unrs/resolver-binding-linux-arm-musleabihf" "1.12.2"
+    "@unrs/resolver-binding-linux-arm64-gnu" "1.12.2"
+    "@unrs/resolver-binding-linux-arm64-musl" "1.12.2"
+    "@unrs/resolver-binding-linux-loong64-gnu" "1.12.2"
+    "@unrs/resolver-binding-linux-loong64-musl" "1.12.2"
+    "@unrs/resolver-binding-linux-ppc64-gnu" "1.12.2"
+    "@unrs/resolver-binding-linux-riscv64-gnu" "1.12.2"
+    "@unrs/resolver-binding-linux-riscv64-musl" "1.12.2"
+    "@unrs/resolver-binding-linux-s390x-gnu" "1.12.2"
+    "@unrs/resolver-binding-linux-x64-gnu" "1.12.2"
+    "@unrs/resolver-binding-linux-x64-musl" "1.12.2"
+    "@unrs/resolver-binding-openharmony-arm64" "1.12.2"
+    "@unrs/resolver-binding-wasm32-wasi" "1.12.2"
+    "@unrs/resolver-binding-win32-arm64-msvc" "1.12.2"
+    "@unrs/resolver-binding-win32-ia32-msvc" "1.12.2"
+    "@unrs/resolver-binding-win32-x64-msvc" "1.12.2"
+
 update-browserslist-db@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz#64d76db58713136acbeb4c49114366cc6cc2e80d"
@@ -6260,6 +7577,15 @@ uuid@^14.0.0, uuid@^7.0.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
   integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
+v8-to-istanbul@^9.0.1:
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz#b9572abfa62bd556c16d75fdebc1a411d5ff3175"
+  integrity sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.12"
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^2.0.0"
+
 validate-npm-package-name@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz#a316573e9b49f3ccd90dbb6eb52b3f06c6d604e8"
@@ -6282,7 +7608,7 @@ walker@^1.0.7, walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
-warn-once@0.1.1:
+warn-once@0.1.1, warn-once@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/warn-once/-/warn-once-0.1.1.tgz#952088f4fb56896e73fd4e6a3767272a3fccce43"
   integrity sha512-VkQZJbO8zVImzYFteBXvBOZEl1qL175WH8VmZcxF2fZAoudNhNDvHi+doCaAEdU2l2vtcIwa2zn0QK5+I1HQ3Q==
@@ -6369,6 +7695,20 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
@@ -6377,6 +7717,15 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
+
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
 
 wrappy@1:
   version "1.0.2"
@@ -6390,6 +7739,14 @@ write-file-atomic@^4.0.2:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
+
+write-file-atomic@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-5.0.1.tgz#68df4717c55c6fa4281a7860b4c2ba0a6d2b11e7"
+  integrity sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==
+  dependencies:
+    imurmurhash "^0.1.4"
+    signal-exit "^4.0.1"
 
 ws@^7, ws@^7.5.10:
   version "7.5.10"
@@ -6451,6 +7808,19 @@ yargs@^17.6.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yargs@^17.7.2:
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"


### PR DESCRIPTION
## Summary
- Email/password auth with SecureStore JWT and Bearer interceptor
- Home flows: new vs human, new vs AI, join by slug, board size picker
- Game screen trusts server board, places/slides via PTN, polls humans, calls `/ai-move` for AI

Depends on server API changes in https://github.com/icco/gotak/pull/135

## Test plan
- [ ] `yarn typecheck && yarn lint && yarn test`
- [ ] Register/login against gotak.app (or local with `EXPO_PUBLIC_API_URL`)
- [ ] Play a full game vs AI (place flat/standing/cap + one stack slide)
- [ ] Create human game, share slug, join from a second account, complete a turn each


Made with [Cursor](https://cursor.com)